### PR TITLE
Fix virtual repo

### DIFF
--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -13,4 +13,4 @@ from pyartifactory.objects import (
     AccessTokenModel,
 )
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -194,7 +194,7 @@ class VirtualRepository(BaseRepositoryModel):
     externalDependenciesRemoteRepo: Optional[str] = None
 
 
-class VirtualRepositoryResponse(LocalRepository):
+class VirtualRepositoryResponse(VirtualRepository):
     """Models a virtual repository response."""
 
     dockerApiVersion: str = "V2"

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -182,6 +182,7 @@ class LocalRepositoryResponse(LocalRepository):
 class VirtualRepository(BaseRepositoryModel):
     """Models a virtual repository."""
 
+    rclass: RClassEnum = RClassEnum.virtual
     repositories: Optional[List[str]] = None
     artifactoryRequestsCanRetrieveRemoteArtifacts: bool = False
     debianTrivialLayout: bool = False
@@ -218,6 +219,7 @@ class VirtualRepositoryResponse(VirtualRepository):
 class RemoteRepository(BaseRepositoryModel):
     """Models a remote Repository."""
 
+    rclass: RClassEnum = RClassEnum.remote
     url: str
     username: Optional[str] = None
     password: Optional[SecretStr] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyArtifactory"
-version = "1.3.0"
+version = "1.3.1"
 description = "Typed interactions with the Jfrog Artifactory REST API"
 authors = ["Ananias CARVALHO <carvalhoananias@hotmail.com>", "Thomas GAUDIN <thomas.gaudin@centraliens-lille.org>"]
 license = "MIT"


### PR DESCRIPTION
## Description

This PR fixes the following issues:
* Make VirtualRepositoryResponse inherit from VirtualRepository instead of LocalRepository
* Overload Virtual & Remote repository models with rclass

Fixes #44 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)