### PR TITLE
Generic repo actions

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@350318022136c903b1dcf90854e65700f78938e1
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - name: Install Poetry
       uses: dschep/install-poetry-action@db2e37f48d1b1cd1491c4590338ebc7699adb425

--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -26,10 +26,6 @@ jobs:
     - name: Install Dependencies
       run: poetry install
 
-    - name: Type checking with mypy
-      run: |
-        poetry run mypy pyartifactory
-
     - name: Lint with pre-commit
       run: |
         poetry run pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,14 @@ repos:
     rev: '19.10b0'
     hooks:
     - id: black
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.740'
+-   repo: local
     hooks:
-    -   id: mypy
+        - id: mypy
+          name: mypy
+          entry: mypy
+          language: system
+          types: [python]
+          files: pyartifactory/
 -   repo: https://github.com/Yelp/detect-secrets
     rev: 'v0.13.0'
     hooks:

--- a/README.md
+++ b/README.md
@@ -184,26 +184,31 @@ Get the list of repositories:
 repositories = art.repositories.list()
 ```
 
-Get a single repository (Local, Virtual or Remote):
+Get a single repository
 ```python
-local_repo = art.repositories.get_local_repo("local_repo_name")
-virtual_repo = art.repositories.get_virtual_repo("virtual_repo_name")
-remote_repo = art.repositories.get_remote_repo("remote_repo_name")
+local_repo = art.repositories.get_repo("repo_name")
 ```
 
 Create/Update a repository:
 ```python
-from pyartifactory.models import LocalRepository, VirtualRepository, RemoteRepository
+from pyartifactory.models import LocalRepository
 
-# Create a repository
+# Create local repo
 local_repo = LocalRepository(key="test_local_repo")
-new_local_repo = art.repositories.create_local_repo(local_repo)
+new_local_repo = art.repositories.create_repo(local_repo)
+
+# Create virtual repo
+virtual_repo = VirtualRepository(key="test_virtual_repo")
+new_virtual_repo = art.repositories.create_repo(virtual_repo)
+
+# Create remote repo
+remote_repo = RemoteRepository(key="test_remote_repo")
+new_remote_repo = art.repositories.create_repo(remote_repo)
 
 # Update a repository
+local_repo = art.repositories.get_repo("test_local_repo")
 local_repo.description = "test_local_repo"
-updated_local_repo = art.repositories.update_local_repo(local_repo)
-
-# Same process for Virtual and Remote repositories
+updated_local_repo = art.repositories.update_repo(local_repo)
 ```
 
 Delete a repository:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 `pyartifactory` is a Python library to access the [Artifactory REST API](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API). 
 
-This library enables you to manage Artifactory resources such as users, groups, permissions, repositories, artifacts and access tokens in your applications.
-It requires at least Python 3.6
+This library enables you to manage Artifactory resources such as users, groups, permissions, repositories, artifacts and access tokens in your applications. Based on Python 3.6+ type hints.
 
 <!-- toc -->
 
+- [Requirements](#requirements)
 - [Install](#install)
 - [Usage](#usage)
   * [Authentication](#authentication)
@@ -35,6 +35,11 @@ It requires at least Python 3.6
   * [Contributing](#contributing)
 
 <!-- tocstop -->
+
+## Requirements
+
+* Python 3.6+
+
 
 ## Install
 
@@ -186,12 +191,13 @@ repositories = art.repositories.list()
 
 Get a single repository
 ```python
-local_repo = art.repositories.get_repo("repo_name")
+repo = art.repositories.get_repo("repo_name")
+# According to the repo type, you'll have either a local, virtual or remote repository returned
 ```
 
 Create/Update a repository:
 ```python
-from pyartifactory.models import LocalRepository
+from pyartifactory.models import LocalRepository, VirtualRepository, RemoteRepository
 
 # Create local repo
 local_repo = LocalRepository(key="test_local_repo")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+plugins = pydantic.mypy
 warn_return_any = True
 warn_unused_configs = True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -555,12 +555,12 @@ python-versions = "*"
 version = "1.4.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4.1"
+version = "3.7.4.2"
 
 [[package]]
 category = "main"
@@ -623,7 +623,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ef341bfa562b42626a2538d882cdbf67d696f093c249004eb07f0eef18f31ae8"
+content-hash = "aeac14286466918b96c1dedf33998cabb1d0ef28fbe0cfd4ae8819fb7a9759a9"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -933,9 +933,9 @@ typed-ast = [
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.1-py2-none-any.whl", hash = "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d"},
-    {file = "typing_extensions-3.7.4.1-py3-none-any.whl", hash = "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"},
-    {file = "typing_extensions-3.7.4.1.tar.gz", hash = "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2"},
+    {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
+    {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
+    {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.8-py2.py3-none-any.whl", hash = "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,11 +89,8 @@ category = "dev"
 description = "Validate configuration and produce human readable error messages."
 name = "cfgv"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.0.1"
-
-[package.dependencies]
-six = "*"
+python-versions = ">=3.6"
+version = "3.0.0"
 
 [[package]]
 category = "main"
@@ -108,8 +105,8 @@ category = "dev"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "7.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.1"
 
 [[package]]
 category = "dev"
@@ -171,6 +168,14 @@ requests = "*"
 word_list = ["pyahocorasick"]
 
 [[package]]
+category = "dev"
+description = "Distribution utilities"
+name = "distlib"
+optional = false
+python-versions = "*"
+version = "0.3.0"
+
+[[package]]
 category = "main"
 description = "DNS toolkit"
 name = "dnspython"
@@ -196,11 +201,19 @@ idna = ">=2.0.0"
 
 [[package]]
 category = "dev"
+description = "A platform independent file lock."
+name = "filelock"
+optional = false
+python-versions = "*"
+version = "3.0.12"
+
+[[package]]
+category = "dev"
 description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.10"
+version = "1.4.11"
 
 [package.extras]
 license = ["editdistance"]
@@ -211,7 +224,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.8"
+version = "2.9"
 
 [[package]]
 category = "dev"
@@ -220,7 +233,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.4.0"
+version = "1.5.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -235,8 +248,20 @@ description = "Read resources from Python packages"
 marker = "python_version < \"3.7\""
 name = "importlib-resources"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "1.0.2"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.3.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
+[package.dependencies.zipp]
+python = "<3.8"
+version = ">=0.4"
+
+[package.extras]
+docs = ["sphinx", "docutils (0.12)", "rst.linker"]
 
 [[package]]
 category = "main"
@@ -274,7 +299,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.1.0"
+version = "8.2.0"
 
 [[package]]
 category = "dev"
@@ -306,7 +331,7 @@ description = "Node.js virtual environment builder"
 name = "nodeenv"
 optional = false
 python-versions = "*"
-version = "1.3.4"
+version = "1.3.5"
 
 [[package]]
 category = "dev"
@@ -372,7 +397,7 @@ description = "Data validation and settings management using python 3.6 type hin
 name = "pydantic"
 optional = false
 python-versions = ">=3.6"
-version = "1.3"
+version = "1.4"
 
 [package.dependencies]
 [package.dependencies.dataclasses]
@@ -380,6 +405,7 @@ python = "<3.7"
 version = ">=0.6"
 
 [package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 typing_extensions = ["typing-extensions (>=3.7.2)"]
 
@@ -458,7 +484,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.1.8"
+version = "2020.2.20"
 
 [[package]]
 category = "main"
@@ -466,16 +492,16 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.22.0"
+version = "2.23.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = ">=3.0.2,<3.1.0"
-idna = ">=2.5,<2.9"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
 [package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
@@ -495,7 +521,7 @@ description = "A utility library for mocking out the `requests` Python library."
 name = "responses"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.10.9"
+version = "0.10.12"
 
 [package.dependencies]
 requests = ">=2.0"
@@ -555,11 +581,25 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "16.7.9"
+version = "20.0.10"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<2"
+distlib = ">=0.3.0,<1"
+filelock = ">=3.0.0,<4"
+six = ">=1.9.0,<2"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12,<2"
+
+[package.dependencies.importlib-resources]
+python = "<3.7"
+version = ">=1.0,<2"
 
 [package.extras]
-docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
-testing = ["pytest (>=4.0.0,<5)", "coverage (>=4.5.0,<5)", "pytest-timeout (>=1.3.0,<2)", "six (>=1.10.0,<2)", "pytest-xdist", "pytest-localserver", "pypiserver", "mock", "xonsh"]
+docs = ["sphinx (>=2.0.0,<3)", "sphinx-argparse (>=0.2.5,<1)", "sphinx-rtd-theme (>=0.4.3,<1)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2,<1)"]
+testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "pytest-timeout (>=1.3.4,<2)", "packaging (>=20.0)", "xonsh (>=0.9.13,<1)"]
 
 [[package]]
 category = "main"
@@ -576,16 +616,14 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.1"
-
-[package.dependencies]
-more-itertools = "*"
+version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "10966df1003ba9b2cc6cc5def16fe38324172c04456de1646273dbddccfeb95b"
+content-hash = "ef341bfa562b42626a2538d882cdbf67d696f093c249004eb07f0eef18f31ae8"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -618,16 +656,16 @@ certifi = [
     {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
 ]
 cfgv = [
-    {file = "cfgv-2.0.1-py2.py3-none-any.whl", hash = "sha256:fbd93c9ab0a523bf7daec408f3be2ed99a980e20b2d19b50fc184ca6b820d289"},
-    {file = "cfgv-2.0.1.tar.gz", hash = "sha256:edb387943b665bf9c434f717bf630fa78aecd53d5900d2e05da6ad6048553144"},
+    {file = "cfgv-3.0.0-py2.py3-none-any.whl", hash = "sha256:f22b426ed59cd2ab2b54ff96608d846c33dfb8766a67f0b4a6ce130ce244414f"},
+    {file = "cfgv-3.0.0.tar.gz", hash = "sha256:04b093b14ddf9fd4d17c53ebfd55582d27b76ed30050193c14e560770c5360eb"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 click = [
-    {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
-    {file = "Click-7.0.tar.gz", hash = "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"},
+    {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
+    {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
 ]
 codacy-coverage = [
     {file = "codacy-coverage-1.3.11.tar.gz", hash = "sha256:b94651934745c638a980ad8d67494077e60f71e19e29aad1c275b66e0a070cbc"},
@@ -678,6 +716,9 @@ detect-secrets = [
     {file = "detect_secrets-0.13.0-py2.py3-none-any.whl", hash = "sha256:8e3cc5bb21fee76e71fee4d57c65b2928b4badb7ae45a5839e70f625057f1a21"},
     {file = "detect_secrets-0.13.0.tar.gz", hash = "sha256:2f1dfe05d1f1bcd46205a46a4117c82a49b2c837771efc625e967c0a710b25a9"},
 ]
+distlib = [
+    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+]
 dnspython = [
     {file = "dnspython-1.16.0-py2.py3-none-any.whl", hash = "sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"},
     {file = "dnspython-1.16.0.zip", hash = "sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01"},
@@ -685,21 +726,25 @@ dnspython = [
 email-validator = [
     {file = "email_validator-1.0.5-py2.py3-none-any.whl", hash = "sha256:e3e6ede1765d7c1e580d2050d834b2689361f7da2d50ce74df6a5968fca7cb13"},
 ]
+filelock = [
+    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
+    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+]
 identify = [
-    {file = "identify-1.4.10-py2.py3-none-any.whl", hash = "sha256:418f3b2313ac0b531139311a6b426854e9cbdfcfb6175447a5039aa6291d8b30"},
-    {file = "identify-1.4.10.tar.gz", hash = "sha256:8ad99ed1f3a965612dcb881435bf58abcfbeb05e230bb8c352b51e8eac103360"},
+    {file = "identify-1.4.11-py2.py3-none-any.whl", hash = "sha256:1222b648251bdcb8deb240b294f450fbf704c7984e08baa92507e4ea10b436d5"},
+    {file = "identify-1.4.11.tar.gz", hash = "sha256:d824ebe21f38325c771c41b08a95a761db1982f1fc0eee37c6c97df3f1636b96"},
 ]
 idna = [
-    {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
-    {file = "idna-2.8.tar.gz", hash = "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"},
+    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
+    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.4.0-py2.py3-none-any.whl", hash = "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359"},
-    {file = "importlib_metadata-1.4.0.tar.gz", hash = "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"},
+    {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
+    {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-1.0.2-py2.py3-none-any.whl", hash = "sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b"},
-    {file = "importlib_resources-1.0.2.tar.gz", hash = "sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"},
+    {file = "importlib_resources-1.3.1-py2.py3-none-any.whl", hash = "sha256:1dff36d42d94bd523eeb847c25c7dd327cb56686d74a26dfcc8d67c504922d59"},
+    {file = "importlib_resources-1.3.1.tar.gz", hash = "sha256:7f0e1b2b5f3981e39c52da0f99b2955353c5a139c314994d1126c2551ace9bdf"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -733,8 +778,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.1.0.tar.gz", hash = "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"},
-    {file = "more_itertools-8.1.0-py3-none-any.whl", hash = "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39"},
+    {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
+    {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
 ]
 mypy = [
     {file = "mypy-0.740-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:9371290aa2cad5ad133e4cdc43892778efd13293406f7340b9ffe99d5ec7c1d9"},
@@ -757,7 +802,7 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nodeenv = [
-    {file = "nodeenv-1.3.4-py2.py3-none-any.whl", hash = "sha256:561057acd4ae3809e665a9aaaf214afff110bbb6a6d5c8a96121aea6878408b3"},
+    {file = "nodeenv-1.3.5-py2.py3-none-any.whl", hash = "sha256:5b2438f2e42af54ca968dd1b374d14a1194848955187b0e5e4be1f73813a5212"},
 ]
 pathspec = [
     {file = "pathspec-0.7.0-py2.py3-none-any.whl", hash = "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424"},
@@ -776,20 +821,20 @@ py = [
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
 ]
 pydantic = [
-    {file = "pydantic-1.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:dd9359db7644317898816f6142f378aa48848dcc5cf14a481236235fde11a148"},
-    {file = "pydantic-1.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cbe284bd5ad67333d49ecc0dc27fa52c25b4c2fe72802a5c060b5f922db58bef"},
-    {file = "pydantic-1.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:2b32a5f14558c36e39aeefda0c550bfc0f47fc32b4ce16d80dc4df2b33838ed8"},
-    {file = "pydantic-1.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:59235324dd7dc5363a654cd14271ea8631f1a43de5d4fc29c782318fcc498002"},
-    {file = "pydantic-1.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:176885123dfdd8f7ab6e7ba1b66d4197de75ba830bb44d921af88b3d977b8aa5"},
-    {file = "pydantic-1.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d4bb6a75abc2f04f6993124f1ed4221724c9dc3bd9df5cb54132e0b68775d375"},
-    {file = "pydantic-1.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:8a8e089aec18c26561e09ee6daf15a3cc06df05bdc67de60a8684535ef54562f"},
-    {file = "pydantic-1.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:479ca8dc7cc41418751bf10302ee0a1b1f8eedb2de6c4f4c0f3cf8372b204f9a"},
-    {file = "pydantic-1.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:87673d1de790c8d5282153cab0b09271be77c49aabcedf3ac5ab1a1fd4dcbac0"},
-    {file = "pydantic-1.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:dacb79144bb3fdb57cf9435e1bd16c35586bc44256215cfaa33bf21565d926ae"},
-    {file = "pydantic-1.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c0da48978382c83f9488c6bbe4350e065ea5c83e85ca5cfb8fa14ac11de3c296"},
-    {file = "pydantic-1.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b60f2b3b0e0dd74f1800a57d1bbd597839d16faf267e45fa4a5407b15d311085"},
-    {file = "pydantic-1.3-py36.py37.py38-none-any.whl", hash = "sha256:d03df07b7611004140b0fef91548878c2b5f48c520a8cb76d11d20e9887a495e"},
-    {file = "pydantic-1.3.tar.gz", hash = "sha256:2eab7d548b0e530bf65bee7855ad8164c2f6a889975d5e9c4eefd1e7c98245dc"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:07911aab70f3bc52bb845ce1748569c5e70478ac977e106a150dd9d0465ebf04"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:012c422859bac2e03ab3151ea6624fecf0e249486be7eb8c6ee69c91740c6752"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:61d22d36808087d3184ed6ac0d91dd71c533b66addb02e4a9930e1e30833202f"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f863456d3d4bf817f2e5248553dee3974c5dc796f48e6ddb599383570f4215ac"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bbbed364376f4a0aebb9ea452ff7968b306499a9e74f4db69b28ff2cd4043a11"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e27559cedbd7f59d2375bfd6eea29a330ea1a5b0589c34d6b4e0d7bec6027bbf"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:50e4e948892a6815649ad5a9a9379ad1e5f090f17842ac206535dfaed75c6f2f"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:8848b4eb458469739126e4c1a202d723dd092e087f8dbe3104371335f87ba5df"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:831a0265a9e3933b3d0f04d1a81bba543bafbe4119c183ff2771871db70524ab"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:47b8db7024ba3d46c3d4768535e1cf87b6c8cf92ccd81e76f4e1cb8ee47688b3"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:51f11c8bbf794a68086540da099aae4a9107447c7a9d63151edbb7d50110cf21"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:6100d7862371115c40be55cc4b8d766a74b1d0dbaf99dbfe72bb4bac0faf89ed"},
+    {file = "pydantic-1.4-py36.py37.py38-none-any.whl", hash = "sha256:72184c1421103cca128300120f8f1185fb42a9ea73a1c9845b1c53db8c026a7d"},
+    {file = "pydantic-1.4.tar.gz", hash = "sha256:f17ec336e64d4583311249fb179528e9a2c27c8a2eaf590ec6ec2c6dece7cb3f"},
 ]
 pylint = [
     {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
@@ -821,39 +866,39 @@ pyyaml = [
     {file = "PyYAML-5.3.tar.gz", hash = "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"},
 ]
 regex = [
-    {file = "regex-2020.1.8-cp27-cp27m-win32.whl", hash = "sha256:4e8f02d3d72ca94efc8396f8036c0d3bcc812aefc28ec70f35bb888c74a25161"},
-    {file = "regex-2020.1.8-cp27-cp27m-win_amd64.whl", hash = "sha256:e6c02171d62ed6972ca8631f6f34fa3281d51db8b326ee397b9c83093a6b7242"},
-    {file = "regex-2020.1.8-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4eae742636aec40cf7ab98171ab9400393360b97e8f9da67b1867a9ee0889b26"},
-    {file = "regex-2020.1.8-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bd25bb7980917e4e70ccccd7e3b5740614f1c408a642c245019cff9d7d1b6149"},
-    {file = "regex-2020.1.8-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3e77409b678b21a056415da3a56abfd7c3ad03da71f3051bbcdb68cf44d3c34d"},
-    {file = "regex-2020.1.8-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:07b39bf943d3d2fe63d46281d8504f8df0ff3fe4c57e13d1656737950e53e525"},
-    {file = "regex-2020.1.8-cp36-cp36m-win32.whl", hash = "sha256:23e2c2c0ff50f44877f64780b815b8fd2e003cda9ce817a7fd00dea5600c84a0"},
-    {file = "regex-2020.1.8-cp36-cp36m-win_amd64.whl", hash = "sha256:27429b8d74ba683484a06b260b7bb00f312e7c757792628ea251afdbf1434003"},
-    {file = "regex-2020.1.8-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0e182d2f097ea8549a249040922fa2b92ae28be4be4895933e369a525ba36576"},
-    {file = "regex-2020.1.8-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e3cd21cc2840ca67de0bbe4071f79f031c81418deb544ceda93ad75ca1ee9f7b"},
-    {file = "regex-2020.1.8-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ecc6de77df3ef68fee966bb8cb4e067e84d4d1f397d0ef6fce46913663540d77"},
-    {file = "regex-2020.1.8-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:26ff99c980f53b3191d8931b199b29d6787c059f2e029b2b0c694343b1708c35"},
-    {file = "regex-2020.1.8-cp37-cp37m-win32.whl", hash = "sha256:7bcd322935377abcc79bfe5b63c44abd0b29387f267791d566bbb566edfdd146"},
-    {file = "regex-2020.1.8-cp37-cp37m-win_amd64.whl", hash = "sha256:10671601ee06cf4dc1bc0b4805309040bb34c9af423c12c379c83d7895622bb5"},
-    {file = "regex-2020.1.8-cp38-cp38-manylinux1_i686.whl", hash = "sha256:98b8ed7bb2155e2cbb8b76f627b2fd12cf4b22ab6e14873e8641f266e0fb6d8f"},
-    {file = "regex-2020.1.8-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6a6ba91b94427cd49cd27764679024b14a96874e0dc638ae6bdd4b1a3ce97be1"},
-    {file = "regex-2020.1.8-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:6a6ae17bf8f2d82d1e8858a47757ce389b880083c4ff2498dba17c56e6c103b9"},
-    {file = "regex-2020.1.8-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:0932941cdfb3afcbc26cc3bcf7c3f3d73d5a9b9c56955d432dbf8bbc147d4c5b"},
-    {file = "regex-2020.1.8-cp38-cp38-win32.whl", hash = "sha256:d58e4606da2a41659c84baeb3cfa2e4c87a74cec89a1e7c56bee4b956f9d7461"},
-    {file = "regex-2020.1.8-cp38-cp38-win_amd64.whl", hash = "sha256:e7c7661f7276507bce416eaae22040fd91ca471b5b33c13f8ff21137ed6f248c"},
-    {file = "regex-2020.1.8.tar.gz", hash = "sha256:d0f424328f9822b0323b3b6f2e4b9c90960b24743d220763c7f07071e0778351"},
+    {file = "regex-2020.2.20-cp27-cp27m-win32.whl", hash = "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb"},
+    {file = "regex-2020.2.20-cp27-cp27m-win_amd64.whl", hash = "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74"},
+    {file = "regex-2020.2.20-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400"},
+    {file = "regex-2020.2.20-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0"},
+    {file = "regex-2020.2.20-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc"},
+    {file = "regex-2020.2.20-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"},
+    {file = "regex-2020.2.20-cp36-cp36m-win32.whl", hash = "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69"},
+    {file = "regex-2020.2.20-cp36-cp36m-win_amd64.whl", hash = "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b"},
+    {file = "regex-2020.2.20-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e"},
+    {file = "regex-2020.2.20-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242"},
+    {file = "regex-2020.2.20-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce"},
+    {file = "regex-2020.2.20-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab"},
+    {file = "regex-2020.2.20-cp37-cp37m-win32.whl", hash = "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431"},
+    {file = "regex-2020.2.20-cp37-cp37m-win_amd64.whl", hash = "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1"},
+    {file = "regex-2020.2.20-cp38-cp38-manylinux1_i686.whl", hash = "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045"},
+    {file = "regex-2020.2.20-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26"},
+    {file = "regex-2020.2.20-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2"},
+    {file = "regex-2020.2.20-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70"},
+    {file = "regex-2020.2.20-cp38-cp38-win32.whl", hash = "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d"},
+    {file = "regex-2020.2.20-cp38-cp38-win_amd64.whl", hash = "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa"},
+    {file = "regex-2020.2.20.tar.gz", hash = "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5"},
 ]
 requests = [
-    {file = "requests-2.22.0-py2.py3-none-any.whl", hash = "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"},
-    {file = "requests-2.22.0.tar.gz", hash = "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"},
+    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
+    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
 ]
 requests-toolbelt = [
     {file = "requests-toolbelt-0.9.1.tar.gz", hash = "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"},
     {file = "requests_toolbelt-0.9.1-py2.py3-none-any.whl", hash = "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"},
 ]
 responses = [
-    {file = "responses-0.10.9-py2.py3-none-any.whl", hash = "sha256:515fd7c024097e5da76e9c4cf719083d181f1c3ddc09c2e0e49284ce863dd263"},
-    {file = "responses-0.10.9.tar.gz", hash = "sha256:8ce8cb4e7e1ad89336f8865af152e0563d2e7f0e0b86d2cf75f015f819409243"},
+    {file = "responses-0.10.12-py2.py3-none-any.whl", hash = "sha256:0474ce3c897fbcc1aef286117c93499882d5c440f06a805947e4b1cb5ab3d474"},
+    {file = "responses-0.10.12.tar.gz", hash = "sha256:f83613479a021e233e82d52ffb3e2e0e2836d24b0cc88a0fa31978789f78d0e5"},
 ]
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
@@ -897,13 +942,13 @@ urllib3 = [
     {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
 ]
 virtualenv = [
-    {file = "virtualenv-16.7.9-py2.py3-none-any.whl", hash = "sha256:55059a7a676e4e19498f1aad09b8313a38fcc0cdbe4fdddc0e9b06946d21b4bb"},
-    {file = "virtualenv-16.7.9.tar.gz", hash = "sha256:0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3"},
+    {file = "virtualenv-20.0.10-py2.py3-none-any.whl", hash = "sha256:10750cac3b5a9e6eed54d0f1f8222c550dc47f84609c95cbc504d44a58a048b8"},
+    {file = "virtualenv-20.0.10.tar.gz", hash = "sha256:8512e83f1d90f8e481024d58512ac9c053bf16f54d9138520a0929396820dd78"},
 ]
 wrapt = [
     {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},
 ]
 zipp = [
-    {file = "zipp-2.0.1-py3-none-any.whl", hash = "sha256:e013e7800f60ec4dde789ebf4e9f7a54236e4bbf5df2a1a4e20ce9e1d9609d67"},
-    {file = "zipp-2.0.1.tar.gz", hash = "sha256:b338014b9bc7102ca69e0fb96ed07215a8954d2989bc5d83658494ab2ba634af"},
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
 ]

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -1,6 +1,7 @@
 """
-Import all object definitions here.
+Import all object definitions here and name the package logger.
 """
+import logging
 
 from pyartifactory.objects import (
     ArtifactoryUser,
@@ -14,3 +15,5 @@ from pyartifactory.objects import (
 )
 
 __version__ = "1.4.0"
+
+logging.getLogger(__name__)

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -13,4 +13,4 @@ from pyartifactory.objects import (
     AccessTokenModel,
 )
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -1,5 +1,5 @@
 """
-Import all object definitions here and name the package logger.
+Import all object definitions here.
 """
 from pyartifactory.objects import (
     ArtifactoryUser,

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -1,8 +1,6 @@
 """
 Import all object definitions here and name the package logger.
 """
-import logging
-
 from pyartifactory.objects import (
     ArtifactoryUser,
     ArtifactoryGroup,
@@ -15,5 +13,3 @@ from pyartifactory.objects import (
 )
 
 __version__ = "1.4.0"
-
-logging.getLogger(__name__)

--- a/pyartifactory/models/__init__.py
+++ b/pyartifactory/models/__init__.py
@@ -1,6 +1,7 @@
 """
 Import all models here.
 """
+from typing import Union
 
 from .auth import AuthModel, ApiKeyModel, PasswordModel, AccessTokenModel
 from .group import Group, SimpleGroup
@@ -17,3 +18,10 @@ from .repository import (
 
 from .artifact import ArtifactPropertiesResponse, ArtifactStatsResponse
 from .permission import Permission, SimplePermission
+
+
+AnyRepositoryResponse = Union[
+    LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
+]
+
+AnyRepository = Union[LocalRepository, VirtualRepository, RemoteRepository]

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -1,8 +1,9 @@
 """
 Definition of all repository models.
 """
-from typing import Optional, List
 from enum import Enum
+from typing import Optional, List
+from typing_extensions import Literal
 
 from pydantic import BaseModel, SecretStr
 
@@ -139,7 +140,7 @@ class BaseRepositoryModel(BaseModel):
 class LocalRepository(BaseRepositoryModel):
     """Models a local repository."""
 
-    rclass: RClassEnum = RClassEnum.local
+    rclass: Literal[RClassEnum.local] = RClassEnum.local
     checksumPolicyType: ChecksumPolicyType = ChecksumPolicyType.client_checksums
     handleReleases: bool = True
     handleSnapshots: bool = True
@@ -183,7 +184,7 @@ class LocalRepositoryResponse(LocalRepository):
 class VirtualRepository(BaseRepositoryModel):
     """Models a virtual repository."""
 
-    rclass: RClassEnum = RClassEnum.virtual
+    rclass: Literal[RClassEnum.virtual] = RClassEnum.virtual
     repositories: Optional[List[str]] = None
     artifactoryRequestsCanRetrieveRemoteArtifacts: bool = False
     debianTrivialLayout: bool = False
@@ -220,7 +221,7 @@ class VirtualRepositoryResponse(VirtualRepository):
 class RemoteRepository(BaseRepositoryModel):
     """Models a remote Repository."""
 
-    rclass: RClassEnum = RClassEnum.remote
+    rclass: Literal[RClassEnum.remote] = RClassEnum.remote
     url: str
     username: Optional[str] = None
     password: Optional[SecretStr] = None

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -127,7 +127,7 @@ class BaseRepositoryModel(BaseModel):
     """Models a base repository."""
 
     key: str
-    rclass: RClassEnum = RClassEnum.local
+    rclass: RClassEnum
     packageType: PackageTypeEnum = PackageTypeEnum.generic
     description: Optional[str] = None
     notes: Optional[str] = None
@@ -139,6 +139,7 @@ class BaseRepositoryModel(BaseModel):
 class LocalRepository(BaseRepositoryModel):
     """Models a local repository."""
 
+    rclass: RClassEnum = RClassEnum.local
     checksumPolicyType: ChecksumPolicyType = ChecksumPolicyType.client_checksums
     handleReleases: bool = True
     handleSnapshots: bool = True

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -2,7 +2,6 @@
 Definition of all artifactory objects.
 """
 import logging
-import warnings
 from typing import List, Optional, Dict, Tuple, Union
 
 from pathlib import Path
@@ -507,10 +506,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: LocalRepository object
         :return: LocalRepositoryResponse object
         """
-        warnings.warn(
-            "`create_local_repo()` is deprecated, use `create_repo` instead",
-            DeprecationWarning,
-        )
         repo_name = repo.key
         try:
             self.get_local_repo(repo_name)
@@ -529,10 +524,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo_name: Name of the repository to retrieve
         :return: LocalRepositoryResponse object
         """
-        warnings.warn(
-            "`get_local_repo()` is deprecated, use `get_repo` instead",
-            DeprecationWarning,
-        )
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
             logger.debug("Repository %s found", repo_name)
@@ -550,10 +541,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: LocalRepository object
         :return: LocalRepositoryResponse
         """
-        warnings.warn(
-            "`update_local_repo()` is deprecated, use `update_repo` instead",
-            DeprecationWarning,
-        )
         repo_name = repo.key
         self.get_local_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
@@ -567,10 +554,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: VirtualRepository object
         :return: VirtualRepositoryResponse object
         """
-        warnings.warn(
-            "`create_virtual_repo()` is deprecated, use `create_repo` instead",
-            DeprecationWarning,
-        )
         repo_name = repo.key
         try:
             self.get_virtual_repo(repo_name)
@@ -589,10 +572,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo_name: Name of the repository to retrieve
         :return: VirtualRepositoryResponse object
         """
-        warnings.warn(
-            "`get_virtual_repo()` is deprecated, use `get_repo` instead",
-            DeprecationWarning,
-        )
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
             logger.debug("Repository %s found", repo_name)
@@ -610,10 +589,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: VirtualRepository object
         :return: VirtualRepositoryResponse
         """
-        warnings.warn(
-            "`update_virtual_repo()` is deprecated, use `update_repo` instead",
-            DeprecationWarning,
-        )
         repo_name = repo.key
         self.get_virtual_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
@@ -627,10 +602,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: RemoteRepository object
         :return: RemoteRepositoryResponse object
         """
-        warnings.warn(
-            "`create_remote_repo()` is deprecated, use `create_repo` instead",
-            DeprecationWarning,
-        )
         repo_name = repo.key
         try:
             self.get_remote_repo(repo_name)
@@ -649,10 +620,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo_name: Name of the repository to retrieve
         :return: RemoteRepositoryResponse object
         """
-        warnings.warn(
-            "`get_remote_repo()` is deprecated, use `get_repo` instead",
-            DeprecationWarning,
-        )
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
             logger.debug("Repository %s found", repo_name)
@@ -670,10 +637,6 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: VirtualRepository object
         :return: VirtualRepositoryResponse
         """
-        warnings.warn(
-            "`update_remote_repo()` is deprecated, use `update_repo` instead",
-            DeprecationWarning,
-        )
         repo_name = repo.key
         self.get_remote_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -37,6 +37,8 @@ from pyartifactory.models import (
     RemoteRepository,
     RemoteRepositoryResponse,
     SimpleRepository,
+    AnyRepository,
+    AnyRepositoryResponse,
     UserResponse,
     NewUser,
     SimpleUser,
@@ -48,9 +50,6 @@ from pyartifactory.models import (
 )
 
 logger = logging.getLogger("pyartifactory")
-AnyRepositoryResponse = Union[
-    LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
-]
 
 
 class Artifactory:
@@ -441,11 +440,7 @@ class ArtifactoryRepository(ArtifactoryObject):
                 )
             raise ArtifactoryException from error
 
-    def create_repo(
-        self, repo: AnyRepositoryResponse
-    ) -> Union[
-        LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
-    ]:
+    def create_repo(self, repo: AnyRepository) -> AnyRepositoryResponse:
         """
         Creates a local, virtual or remote repository
         :param repo: Either a local, virtual or remote repository
@@ -463,11 +458,7 @@ class ArtifactoryRepository(ArtifactoryObject):
             logger.debug("Repository %s successfully created", repo_name)
             return self.get_repo(repo_name)
 
-    def update_repo(
-        self, repo: AnyRepositoryResponse
-    ) -> Union[
-        LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
-    ]:
+    def update_repo(self, repo: AnyRepository) -> AnyRepositoryResponse:
         """
         Updates a local, virtual or remote repository
         :param repo: Either a local, virtual or remote repository

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -2,6 +2,7 @@
 Definition of all artifactory objects.
 """
 import logging
+import warnings
 from typing import List, Optional, Dict, Tuple, Union
 
 from pathlib import Path
@@ -45,7 +46,6 @@ from pyartifactory.models import (
     ArtifactPropertiesResponse,
     ArtifactStatsResponse,
 )
-from pyartifactory.models.repository import BaseRepositoryModel
 
 logger = logging.getLogger("pyartifactory")
 
@@ -419,21 +419,29 @@ class ArtifactoryRepository(ArtifactoryObject):
         LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
     ]:
         """
-        Finds repository in artifactory. Fill object if exist
+        Finds repository in artifactory. Raises an exception if the repo doesn't exist.
         :param repo_name: Name of the repository to retrieve
-        :return: LocalRepositoryResponse, VirtualRepositoryResponse or RemoteRepositoryResponse object
+        :return: Either a local, virtual or remote repository
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
-            repo = parse_obj_as(BaseRepositoryModel, response.json())
+            repo = parse_obj_as(
+                Union[
+                    LocalRepositoryResponse,
+                    VirtualRepositoryResponse,
+                    RemoteRepositoryResponse,
+                ],
+                response.json(),
+            )
+
             found_repo: Union[
                 LocalRepositoryResponse,
                 VirtualRepositoryResponse,
                 RemoteRepositoryResponse,
             ]
-            if repo.rclass == "local":
+            if type(repo).__name__ == "LocalRepository":
                 found_repo = self.get_local_repo(repo_name)
-            elif repo.rclass == "virtual":
+            elif type(repo).__name__ == "VirtualRepository":
                 found_repo = self.get_virtual_repo(repo_name)
             else:
                 found_repo = self.get_remote_repo(repo_name)
@@ -499,6 +507,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: LocalRepository object
         :return: LocalRepositoryResponse object
         """
+        warnings.warn(
+            "`create_local_repo()` is deprecated, use `create_repo` instead",
+            DeprecationWarning,
+        )
         repo_name = repo.key
         try:
             self.get_local_repo(repo_name)
@@ -517,6 +529,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo_name: Name of the repository to retrieve
         :return: LocalRepositoryResponse object
         """
+        warnings.warn(
+            "`get_local_repo()` is deprecated, use `get_repo` instead",
+            DeprecationWarning,
+        )
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
             logger.debug("Repository %s found", repo_name)
@@ -534,6 +550,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: LocalRepository object
         :return: LocalRepositoryResponse
         """
+        warnings.warn(
+            "`update_local_repo()` is deprecated, use `update_repo` instead",
+            DeprecationWarning,
+        )
         repo_name = repo.key
         self.get_local_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
@@ -547,6 +567,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: VirtualRepository object
         :return: VirtualRepositoryResponse object
         """
+        warnings.warn(
+            "`create_virtual_repo()` is deprecated, use `create_repo` instead",
+            DeprecationWarning,
+        )
         repo_name = repo.key
         try:
             self.get_virtual_repo(repo_name)
@@ -565,6 +589,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo_name: Name of the repository to retrieve
         :return: VirtualRepositoryResponse object
         """
+        warnings.warn(
+            "`get_virtual_repo()` is deprecated, use `get_repo` instead",
+            DeprecationWarning,
+        )
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
             logger.debug("Repository %s found", repo_name)
@@ -582,6 +610,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: VirtualRepository object
         :return: VirtualRepositoryResponse
         """
+        warnings.warn(
+            "`update_virtual_repo()` is deprecated, use `update_repo` instead",
+            DeprecationWarning,
+        )
         repo_name = repo.key
         self.get_virtual_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
@@ -595,6 +627,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: RemoteRepository object
         :return: RemoteRepositoryResponse object
         """
+        warnings.warn(
+            "`create_remote_repo()` is deprecated, use `create_repo` instead",
+            DeprecationWarning,
+        )
         repo_name = repo.key
         try:
             self.get_remote_repo(repo_name)
@@ -613,6 +649,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo_name: Name of the repository to retrieve
         :return: RemoteRepositoryResponse object
         """
+        warnings.warn(
+            "`get_remote_repo()` is deprecated, use `get_repo` instead",
+            DeprecationWarning,
+        )
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
             logger.debug("Repository %s found", repo_name)
@@ -630,6 +670,10 @@ class ArtifactoryRepository(ArtifactoryObject):
         :param repo: VirtualRepository object
         :return: VirtualRepositoryResponse
         """
+        warnings.warn(
+            "`update_remote_repo()` is deprecated, use `update_repo` instead",
+            DeprecationWarning,
+        )
         repo_name = repo.key
         self.get_remote_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -1,7 +1,6 @@
 """
 Definition of all artifactory objects.
 """
-
 import logging
 from typing import List, Optional, Dict, Tuple, Union
 
@@ -286,7 +285,7 @@ class ArtifactorySecurity(ArtifactoryObject):
             f"api/{self._uri}/token/revoke", data=payload, raise_for_status=False
         )
         if response.ok:
-            logging.info("Token revoked successfully, or token did not exist")
+            logging.debug("Token revoked successfully, or token did not exist")
             return True
         logging.error("Token revocation unsuccessful, response was %s", response.text)
         return False
@@ -742,7 +741,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             )
             headers = {"Prefer": "respond-async", "Content-Type": form.content_type}
             self._put(f"{artifact_path}", headers=headers, data=form)
-            logging.info("Artifact %s successfully deployed", local_filename)
+            logging.debug("Artifact %s successfully deployed", local_filename)
             return self.properties(artifact_path)
 
     def download(self, artifact_path: str, local_directory_path: str = None) -> str:
@@ -765,7 +764,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:  # filter out keep-alive new chunks
                         file.write(chunk)
-        logging.info("Artifact %s successfully downloaded", local_filename)
+        logging.debug("Artifact %s successfully downloaded", local_filename)
         return local_file_full_path
 
     def properties(self, artifact_path: str) -> ArtifactPropertiesResponse:
@@ -775,7 +774,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.lstrip("/")
         response = self._get(f"api/storage/{artifact_path}?properties[=x[,y]]")
-        logging.info("Artifact Properties successfully retrieved")
+        logging.debug("Artifact Properties successfully retrieved")
         return ArtifactPropertiesResponse(**response.json())
 
     def stats(self, artifact_path: str) -> ArtifactStatsResponse:
@@ -785,7 +784,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.lstrip("/")
         response = self._get(f"api/storage/{artifact_path}?stats")
-        logging.info("Artifact stats successfully retrieved")
+        logging.debug("Artifact stats successfully retrieved")
         return ArtifactStatsResponse(**response.json())
 
     def copy(
@@ -805,7 +804,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             dry = 0
 
         self._post(f"api/copy/{artifact_current_path}?to={artifact_new_path}&dry={dry}")
-        logging.info("Artifact %s successfully copied", artifact_current_path)
+        logging.debug("Artifact %s successfully copied", artifact_current_path)
         return self.properties(artifact_new_path)
 
     def move(
@@ -826,7 +825,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             dry = 0
 
         self._post(f"api/move/{artifact_current_path}?to={artifact_new_path}&dry={dry}")
-        logging.info("Artifact %s successfully moved", artifact_current_path)
+        logging.debug("Artifact %s successfully moved", artifact_current_path)
         return self.properties(artifact_new_path)
 
     def delete(self, artifact_path: str) -> None:
@@ -836,4 +835,4 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.lstrip("/")
         self._delete(f"{artifact_path}")
-        logging.info("Artifact %s successfully deleted", artifact_path)
+        logging.debug("Artifact %s successfully deleted", artifact_path)

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -47,6 +47,8 @@ from pyartifactory.models import (
 )
 from pyartifactory.models.repository import BaseRepositoryModel
 
+logger = logging.getLogger("pyartifactory")
+
 
 class Artifactory:
     """Models artifactory."""
@@ -149,13 +151,13 @@ class ArtifactoryUser(ArtifactoryObject):
         username = user.name
         try:
             self.get(username)
-            logging.error("User %s already exists", username)
+            logger.error("User %s already exists", username)
             raise UserAlreadyExistsException(f"User {username} already exists")
         except UserNotFoundException:
             data = user.dict()
             data["password"] = user.password.get_secret_value()
             self._put(f"api/{self._uri}/{username}", json=data)
-            logging.debug("User %s successfully created", username)
+            logger.debug("User %s successfully created", username)
             return self.get(user.name)
 
     def get(self, name: str) -> UserResponse:
@@ -166,11 +168,11 @@ class ArtifactoryUser(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{name}")
-            logging.debug("User %s found", name)
+            logger.debug("User %s found", name)
             return UserResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
-                logging.error("User %s does not exist", name)
+                logger.error("User %s does not exist", name)
                 raise UserNotFoundException(f"{name} does not exist")
             raise ArtifactoryException from error
 
@@ -180,7 +182,7 @@ class ArtifactoryUser(ArtifactoryObject):
         :return: UserList
         """
         response = self._get(f"api/{self._uri}")
-        logging.debug("List all users successful")
+        logger.debug("List all users successful")
         return [SimpleUser(**user) for user in response.json()]
 
     def update(self, user: User) -> UserResponse:
@@ -192,7 +194,7 @@ class ArtifactoryUser(ArtifactoryObject):
         username = user.name
         self.get(username)
         self._post(f"api/{self._uri}/{username}", json=user.dict())
-        logging.debug("User %s successfully updated", username)
+        logger.debug("User %s successfully updated", username)
         return self.get(username)
 
     def delete(self, name: str) -> None:
@@ -203,7 +205,7 @@ class ArtifactoryUser(ArtifactoryObject):
         """
         self.get(name)
         self._delete(f"api/{self._uri}/{name}")
-        logging.debug("User %s successfully deleted", name)
+        logger.debug("User %s successfully deleted", name)
 
     def unlock(self, name: str) -> None:
         """
@@ -213,7 +215,7 @@ class ArtifactoryUser(ArtifactoryObject):
         :return none
         """
         self._post(f"api/security/unlockUsers/{name}")
-        logging.debug("User % successfully unlocked", name)
+        logger.debug("User % successfully unlocked", name)
 
 
 class ArtifactorySecurity(ArtifactoryObject):
@@ -227,7 +229,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: str
         """
         response = self._get(f"api/{self._uri}/encryptedPassword")
-        logging.debug("Encrypted password successfully delivered")
+        logger.debug("Encrypted password successfully delivered")
         return PasswordModel(**response.json())
 
     def create_access_token(
@@ -277,7 +279,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: bool True or False indicating success or failure of token revocation attempt.
         """
         if not any([token, token_id]):
-            logging.error("Neither a token or a token id was specified")
+            logger.error("Neither a token or a token id was specified")
             raise InvalidTokenDataException
         payload: Dict[str, Optional[str]] = {"token": token} if token else {
             "token_id": token_id
@@ -286,9 +288,9 @@ class ArtifactorySecurity(ArtifactoryObject):
             f"api/{self._uri}/token/revoke", data=payload, raise_for_status=False
         )
         if response.ok:
-            logging.debug("Token revoked successfully, or token did not exist")
+            logger.debug("Token revoked successfully, or token did not exist")
             return True
-        logging.error("Token revocation unsuccessful, response was %s", response.text)
+        logger.error("Token revocation unsuccessful, response was %s", response.text)
         return False
 
     def create_api_key(self) -> ApiKeyModel:
@@ -297,7 +299,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: Error if API key already exists - use regenerate API key instead.
         """
         response = self._post(f"api/{self._uri}/apiKey")
-        logging.debug("API Key successfully created")
+        logger.debug("API Key successfully created")
         return ApiKeyModel(**response.json())
 
     def regenerate_api_key(self) -> ApiKeyModel:
@@ -306,7 +308,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: API key
         """
         response = self._put(f"api/{self._uri}/apiKey")
-        logging.debug("API Key successfully regenerated")
+        logger.debug("API Key successfully regenerated")
         return ApiKeyModel(**response.json())
 
     def get_api_key(self) -> ApiKeyModel:
@@ -315,7 +317,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: API key
         """
         response = self._get(f"api/{self._uri}/apiKey")
-        logging.debug("API Key successfully delivered")
+        logger.debug("API Key successfully delivered")
         return ApiKeyModel(**response.json())
 
     def revoke_api_key(self) -> None:
@@ -324,7 +326,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: None
         """
         self._delete(f"api/{self._uri}/apiKey")
-        logging.debug("API Key successfully revoked")
+        logger.debug("API Key successfully revoked")
 
     def revoke_user_api_key(self, name: str) -> None:
         """
@@ -333,7 +335,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         :return: None
         """
         self._delete(f"api/{self._uri}/apiKey/{name}")
-        logging.debug("User API Key successfully revoked")
+        logger.debug("User API Key successfully revoked")
 
 
 class ArtifactoryGroup(ArtifactoryObject):
@@ -350,11 +352,11 @@ class ArtifactoryGroup(ArtifactoryObject):
         group_name = group.name
         try:
             self.get(group_name)
-            logging.error("Group %s already exists", group_name)
+            logger.error("Group %s already exists", group_name)
             raise GroupAlreadyExistsException(f"Group {group_name} already exists")
         except GroupNotFoundException:
             self._put(f"api/{self._uri}/{group_name}", json=group.dict())
-            logging.debug("Group %s successfully created", group_name)
+            logger.debug("Group %s successfully created", group_name)
             return self.get(group.name)
 
     def get(self, name: str) -> Group:
@@ -365,11 +367,11 @@ class ArtifactoryGroup(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{name}")
-            logging.debug("Group %s found", name)
+            logger.debug("Group %s found", name)
             return Group(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
-                logging.error("Group %s does not exist", name)
+                logger.error("Group %s does not exist", name)
                 raise GroupNotFoundException(f"Group {name} does not exist")
             raise ArtifactoryException from error
 
@@ -379,7 +381,7 @@ class ArtifactoryGroup(ArtifactoryObject):
         :return: GroupList
         """
         response = self._get(f"api/{self._uri}")
-        logging.debug("List all groups successful")
+        logger.debug("List all groups successful")
         return [Group(**group) for group in response.json()]
 
     def update(self, group: Group) -> Group:
@@ -391,7 +393,7 @@ class ArtifactoryGroup(ArtifactoryObject):
         group_name = group.name
         self.get(group_name)
         self._post(f"api/{self._uri}/{group_name}", json=group.dict())
-        logging.debug("Group %s successfully updated", group_name)
+        logger.debug("Group %s successfully updated", group_name)
         return self.get(group_name)
 
     def delete(self, name: str) -> None:
@@ -402,7 +404,7 @@ class ArtifactoryGroup(ArtifactoryObject):
         """
         self.get(name)
         self._delete(f"api/{self._uri}/{name}")
-        logging.debug("Group %s successfully deleted", name)
+        logger.debug("Group %s successfully deleted", name)
 
 
 class ArtifactoryRepository(ArtifactoryObject):
@@ -438,7 +440,7 @@ class ArtifactoryRepository(ArtifactoryObject):
             return found_repo
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
-                logging.error("Repository %s does not exist", repo_name)
+                logger.error("Repository %s does not exist", repo_name)
                 raise RepositoryNotFoundException(
                     f" Repository {repo_name} does not exist"
                 )
@@ -500,13 +502,13 @@ class ArtifactoryRepository(ArtifactoryObject):
         repo_name = repo.key
         try:
             self.get_local_repo(repo_name)
-            logging.error("Repository %s already exists", repo_name)
+            logger.error("Repository %s already exists", repo_name)
             raise RepositoryAlreadyExistsException(
                 f"Repository {repo_name} already exists"
             )
         except RepositoryNotFoundException:
             self._put(f"api/{self._uri}/{repo_name}", json=repo.dict())
-            logging.debug("Repository %s successfully created", repo_name)
+            logger.debug("Repository %s successfully created", repo_name)
             return self.get_local_repo(repo_name)
 
     def get_local_repo(self, repo_name: str) -> LocalRepositoryResponse:
@@ -517,7 +519,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
-            logging.debug("Repository %s found", repo_name)
+            logger.debug("Repository %s found", repo_name)
             return LocalRepositoryResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -535,7 +537,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         repo_name = repo.key
         self.get_local_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
-        logging.debug("Repository %s successfully updated", repo_name)
+        logger.debug("Repository %s successfully updated", repo_name)
         return self.get_local_repo(repo_name)
 
     # Virtual repositories operations
@@ -548,13 +550,13 @@ class ArtifactoryRepository(ArtifactoryObject):
         repo_name = repo.key
         try:
             self.get_virtual_repo(repo_name)
-            logging.error("Repository %s already exists", repo_name)
+            logger.error("Repository %s already exists", repo_name)
             raise RepositoryAlreadyExistsException(
                 f"Repository {repo_name} already exists"
             )
         except RepositoryNotFoundException:
             self._put(f"api/{self._uri}/{repo_name}", json=repo.dict())
-            logging.debug("Repository %s successfully created", repo_name)
+            logger.debug("Repository %s successfully created", repo_name)
             return self.get_virtual_repo(repo_name)
 
     def get_virtual_repo(self, repo_name: str) -> VirtualRepositoryResponse:
@@ -565,7 +567,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
-            logging.debug("Repository %s found", repo_name)
+            logger.debug("Repository %s found", repo_name)
             return VirtualRepositoryResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -583,7 +585,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         repo_name = repo.key
         self.get_virtual_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
-        logging.debug("Repository %s successfully updated", repo_name)
+        logger.debug("Repository %s successfully updated", repo_name)
         return self.get_virtual_repo(repo_name)
 
     # Remote repositories operations
@@ -596,13 +598,13 @@ class ArtifactoryRepository(ArtifactoryObject):
         repo_name = repo.key
         try:
             self.get_remote_repo(repo_name)
-            logging.error("Repository %s already exists", repo_name)
+            logger.error("Repository %s already exists", repo_name)
             raise RepositoryAlreadyExistsException(
                 f"Repository {repo_name} already exists"
             )
         except RepositoryNotFoundException:
             self._put(f"api/{self._uri}/{repo_name}", json=repo.dict())
-            logging.debug("Repository %s successfully created", repo_name)
+            logger.debug("Repository %s successfully created", repo_name)
             return self.get_remote_repo(repo_name)
 
     def get_remote_repo(self, repo_name: str) -> RemoteRepositoryResponse:
@@ -613,7 +615,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
-            logging.debug("Repository %s found", repo_name)
+            logger.debug("Repository %s found", repo_name)
             return RemoteRepositoryResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -631,7 +633,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         repo_name = repo.key
         self.get_remote_repo(repo_name)
         self._post(f"api/{self._uri}/{repo_name}", json=repo.dict())
-        logging.debug("Repository %s successfully updated", repo_name)
+        logger.debug("Repository %s successfully updated", repo_name)
         return self.get_remote_repo(repo_name)
 
     def list(self) -> List[SimpleRepository]:
@@ -640,7 +642,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         :return: A list of repositories
         """
         response = self._get(f"api/{self._uri}")
-        logging.debug("List all repositories successful")
+        logger.debug("List all repositories successful")
         return [SimpleRepository(**repository) for repository in response.json()]
 
     def delete(self, repo_name: str) -> None:
@@ -651,7 +653,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
 
         self._delete(f"api/{self._uri}/{repo_name}")
-        logging.debug("Repository %s successfully deleted", repo_name)
+        logger.debug("Repository %s successfully deleted", repo_name)
 
 
 class ArtifactoryPermission(ArtifactoryObject):
@@ -668,13 +670,13 @@ class ArtifactoryPermission(ArtifactoryObject):
         permission_name = permission.name
         try:
             self.get(permission_name)
-            logging.debug("Permission %s already exists", permission_name)
+            logger.debug("Permission %s already exists", permission_name)
             raise PermissionAlreadyExistsException(
                 f"Permission {permission_name} already exists"
             )
         except PermissionNotFoundException:
             self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
-            logging.debug("Permission %s successfully created", permission_name)
+            logger.debug("Permission %s successfully created", permission_name)
             return self.get(permission_name)
 
     def get(self, permission_name: str) -> Permission:
@@ -685,11 +687,11 @@ class ArtifactoryPermission(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{permission_name}")
-            logging.debug("Permission %s found", permission_name)
+            logger.debug("Permission %s found", permission_name)
             return Permission(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
-                logging.error("Permission %s does not exist", permission_name)
+                logger.error("Permission %s does not exist", permission_name)
                 raise PermissionNotFoundException(
                     f"Permission {permission_name} does not exist"
                 )
@@ -701,7 +703,7 @@ class ArtifactoryPermission(ArtifactoryObject):
         :return: A list of permissions
         """
         response = self._get(f"api/{self._uri}")
-        logging.debug("List all permissions successful")
+        logger.debug("List all permissions successful")
         return [SimplePermission(**permission) for permission in response.json()]
 
     def update(self, permission: Permission) -> Permission:
@@ -712,7 +714,7 @@ class ArtifactoryPermission(ArtifactoryObject):
         """
         permission_name = permission.name
         self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
-        logging.debug("Permission %s successfully updated", permission_name)
+        logger.debug("Permission %s successfully updated", permission_name)
         return self.get(permission_name)
 
     def delete(self, permission_name: str) -> None:
@@ -723,7 +725,7 @@ class ArtifactoryPermission(ArtifactoryObject):
         """
         self.get(permission_name)
         self._delete(f"api/{self._uri}/{permission_name}")
-        logging.debug("Permission %s successfully deleted", permission_name)
+        logger.debug("Permission %s successfully deleted", permission_name)
 
 
 class ArtifactoryArtifact(ArtifactoryObject):
@@ -747,7 +749,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             )
             headers = {"Prefer": "respond-async", "Content-Type": form.content_type}
             self._put(f"{artifact_path}", headers=headers, data=form)
-            logging.debug("Artifact %s successfully deployed", local_filename)
+            logger.debug("Artifact %s successfully deployed", local_filename)
             return self.properties(artifact_path)
 
     def download(self, artifact_path: str, local_directory_path: str = None) -> str:
@@ -770,7 +772,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:  # filter out keep-alive new chunks
                         file.write(chunk)
-        logging.debug("Artifact %s successfully downloaded", local_filename)
+        logger.debug("Artifact %s successfully downloaded", local_filename)
         return local_file_full_path
 
     def properties(self, artifact_path: str) -> ArtifactPropertiesResponse:
@@ -780,7 +782,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.lstrip("/")
         response = self._get(f"api/storage/{artifact_path}?properties[=x[,y]]")
-        logging.debug("Artifact Properties successfully retrieved")
+        logger.debug("Artifact Properties successfully retrieved")
         return ArtifactPropertiesResponse(**response.json())
 
     def stats(self, artifact_path: str) -> ArtifactStatsResponse:
@@ -790,7 +792,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.lstrip("/")
         response = self._get(f"api/storage/{artifact_path}?stats")
-        logging.debug("Artifact stats successfully retrieved")
+        logger.debug("Artifact stats successfully retrieved")
         return ArtifactStatsResponse(**response.json())
 
     def copy(
@@ -810,7 +812,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             dry = 0
 
         self._post(f"api/copy/{artifact_current_path}?to={artifact_new_path}&dry={dry}")
-        logging.debug("Artifact %s successfully copied", artifact_current_path)
+        logger.debug("Artifact %s successfully copied", artifact_current_path)
         return self.properties(artifact_new_path)
 
     def move(
@@ -831,7 +833,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             dry = 0
 
         self._post(f"api/move/{artifact_current_path}?to={artifact_new_path}&dry={dry}")
-        logging.debug("Artifact %s successfully moved", artifact_current_path)
+        logger.debug("Artifact %s successfully moved", artifact_current_path)
         return self.properties(artifact_new_path)
 
     def delete(self, artifact_path: str) -> None:
@@ -841,4 +843,4 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.lstrip("/")
         self._delete(f"{artifact_path}")
-        logging.debug("Artifact %s successfully deleted", artifact_path)
+        logger.debug("Artifact %s successfully deleted", artifact_path)

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -439,9 +439,9 @@ class ArtifactoryRepository(ArtifactoryObject):
                 VirtualRepositoryResponse,
                 RemoteRepositoryResponse,
             ]
-            if type(repo).__name__ == "LocalRepository":
+            if repo.rclass == "local":
                 found_repo = self.get_local_repo(repo_name)
-            elif type(repo).__name__ == "VirtualRepository":
+            elif repo.rclass == "virtual":
                 found_repo = self.get_virtual_repo(repo_name)
             else:
                 found_repo = self.get_remote_repo(repo_name)

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -48,6 +48,9 @@ from pyartifactory.models import (
 )
 
 logger = logging.getLogger("pyartifactory")
+AnyRepositoryResponse = Union[
+    LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
+]
 
 
 class Artifactory:
@@ -413,11 +416,7 @@ class ArtifactoryRepository(ArtifactoryObject):
     _uri = "repositories"
 
     # Repositories operations
-    def get_repo(
-        self, repo_name: str
-    ) -> Union[
-        LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
-    ]:
+    def get_repo(self, repo_name: str) -> AnyRepositoryResponse:
         """
         Finds repository in artifactory. Raises an exception if the repo doesn't exist.
         :param repo_name: Name of the repository to retrieve
@@ -425,11 +424,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
-            repo: Union[
-                LocalRepositoryResponse,
-                VirtualRepositoryResponse,
-                RemoteRepositoryResponse,
-            ] = parse_obj_as(
+            repo: AnyRepositoryResponse = parse_obj_as(
                 Union[
                     LocalRepositoryResponse,
                     VirtualRepositoryResponse,
@@ -447,7 +442,7 @@ class ArtifactoryRepository(ArtifactoryObject):
             raise ArtifactoryException from error
 
     def create_repo(
-        self, repo: Union[LocalRepository, VirtualRepository, RemoteRepository]
+        self, repo: AnyRepositoryResponse
     ) -> Union[
         LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
     ]:
@@ -469,7 +464,7 @@ class ArtifactoryRepository(ArtifactoryObject):
             return self.get_repo(repo_name)
 
     def update_repo(
-        self, repo: Union[LocalRepository, VirtualRepository, RemoteRepository]
+        self, repo: AnyRepositoryResponse
     ) -> Union[
         LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse
     ]:

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -166,6 +166,7 @@ class ArtifactoryUser(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{name}")
+            logging.debug("User %s found", name)
             return UserResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -364,6 +365,7 @@ class ArtifactoryGroup(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{name}")
+            logging.debug("Group %s found", name)
             return Group(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -515,6 +517,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
+            logging.debug("Repository %s found", repo_name)
             return LocalRepositoryResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -562,6 +565,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
+            logging.debug("Repository %s found", repo_name)
             return VirtualRepositoryResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -609,6 +613,7 @@ class ArtifactoryRepository(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{repo_name}")
+            logging.debug("Repository %s found", repo_name)
             return RemoteRepositoryResponse(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:
@@ -680,6 +685,7 @@ class ArtifactoryPermission(ArtifactoryObject):
         """
         try:
             response = self._get(f"api/{self._uri}/{permission_name}")
+            logging.debug("Permission %s found", permission_name)
             return Permission(**response.json())
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404 or error.response.status_code == 400:

--- a/pylintrc
+++ b/pylintrc
@@ -6,3 +6,6 @@ disable=bad-continuation,
         line-too-long,
         too-few-public-methods,
         import-error
+
+[BASIC]
+good-names=logger

--- a/pylintrc
+++ b/pylintrc
@@ -8,4 +8,4 @@ disable=bad-continuation,
         import-error
 
 [BASIC]
-good-names=logger
+good-names=logger,i,j,k,ex,Run,_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ python = "^3.6"
 requests = "^2.21"
 email_validator = "^1.0"
 requests_toolbelt = "^0.9.1"
-pydantic = "^1.3"
 pylint = "2.4.4"
+pydantic = "^1.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ email_validator = "^1.0"
 requests_toolbelt = "^0.9.1"
 pylint = "2.4.4"
 pydantic = "^1.4"
+typing_extensions = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyArtifactory"
-version = "1.3.1"
+version = "1.4.0"
 description = "Typed interactions with the Jfrog Artifactory REST API"
 authors = ["Ananias CARVALHO <carvalhoananias@hotmail.com>", "Thomas GAUDIN <thomas.gaudin@centraliens-lille.org>"]
 license = "MIT"

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -32,33 +32,25 @@ UPDATED_LOCAL_REPOSITORY = LocalRepository(
 UPDATED_LOCAL_REPOSITORY_RESPONSE = LocalRepositoryResponse(
     key="test_local_repository", description="updated"
 )
-VIRTUAL_REPOSITORY = VirtualRepository(key="test_virtual_repository", rclass="virtual")
-VIRTUAL_REPOSITORY_RESPONSE = VirtualRepositoryResponse(
-    key="test_virtual_repository", rclass="virtual"
-)
+VIRTUAL_REPOSITORY = VirtualRepository(key="test_virtual_repository")
+VIRTUAL_REPOSITORY_RESPONSE = VirtualRepositoryResponse(key="test_virtual_repository")
 UPDATED_VIRTUAL_REPOSITORY = VirtualRepository(
-    key="test_virtual_repository", rclass="virtual", description="updated"
+    key="test_virtual_repository", description="updated"
 )
 UPDATED_VIRTUAL_REPOSITORY_RESPONSE = VirtualRepositoryResponse(
-    key="test_virtual_repository", rclass="virtual", description="updated"
+    key="test_virtual_repository", description="updated"
 )
 REMOTE_REPOSITORY = RemoteRepository(
-    key="test_remote_repository", url="http://test-url.com", rclass="remote"
+    key="test_remote_repository", url="http://test-url.com"
 )
 REMOTE_REPOSITORY_RESPONSE = RemoteRepositoryResponse(
-    key="test_remote_repository", url="http://test-url.com", rclass="remote"
+    key="test_remote_repository", url="http://test-url.com"
 )
 UPDATED_REMOTE_REPOSITORY = RemoteRepository(
-    key="test_remote_repository",
-    url="http://test-url.com",
-    rclass="remote",
-    description="updated",
+    key="test_remote_repository", url="http://test-url.com", description="updated",
 )
 UPDATED_REMOTE_REPOSITORY_RESPONSE = RemoteRepositoryResponse(
-    key="test_remote_repository",
-    url="http://test-url.com",
-    rclass="remote",
-    description="updated",
+    key="test_remote_repository", url="http://test-url.com", description="updated",
 )
 
 
@@ -76,7 +68,7 @@ def test_create_local_repository_using_create_repo_fail_if_user_already_exists(m
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(LOCAL_REPOSITORY)
 
-        artifactory_repo.create_local_repo.assert_called_once_with(LOCAL_REPOSITORY)
+    artifactory_repo.create_local_repo.assert_called_once_with(LOCAL_REPOSITORY)
 
 
 @responses.activate
@@ -93,7 +85,7 @@ def test_create_local_repository_fail_if_user_already_exists(mocker):
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_local_repo(LOCAL_REPOSITORY)
 
-        artifactory_repo.get_local_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
+    artifactory_repo.get_local_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -103,7 +95,7 @@ def test_create_virtual_repository_using_create_repo_fail_if_user_already_exists
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{VIRTUAL_REPOSITORY.key}",
-        json=LOCAL_REPOSITORY_RESPONSE.dict(),
+        json=VIRTUAL_REPOSITORY_RESPONSE.dict(),
         status=200,
     )
 
@@ -112,7 +104,7 @@ def test_create_virtual_repository_using_create_repo_fail_if_user_already_exists
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
 
-        artifactory_repo.create_local_repo.assert_called_once_with(VIRTUAL_REPOSITORY)
+    artifactory_repo.create_virtual_repo.assert_called_once_with(VIRTUAL_REPOSITORY)
 
 
 @responses.activate
@@ -129,9 +121,7 @@ def test_create_virtual_repository_fail_if_user_already_exists(mocker):
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_virtual_repo(VIRTUAL_REPOSITORY)
 
-        artifactory_repo.get_virtual_repo.assert_called_once_with(
-            VIRTUAL_REPOSITORY.key
-        )
+    artifactory_repo.get_virtual_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -148,7 +138,7 @@ def test_create_remote_repository_using_create_repo_fail_if_user_already_exists(
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(REMOTE_REPOSITORY)
 
-        artifactory_repo.create_local_repo.assert_called_once_with(REMOTE_REPOSITORY)
+    artifactory_repo.create_remote_repo.assert_called_once_with(REMOTE_REPOSITORY)
 
 
 @responses.activate
@@ -165,7 +155,7 @@ def test_create_remote_repository_fail_if_user_already_exists(mocker):
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_remote_repo(REMOTE_REPOSITORY)
 
-        artifactory_repo.get_remote_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
+    artifactory_repo.get_remote_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
 
 
 @responses.activate
@@ -403,7 +393,7 @@ def test_get_remote_repository_error_not_found():
 
 
 @responses.activate
-def test_get_local_repositoryusing_get_repo_success(mocker):
+def test_get_local_repository_using_get_repo_success(mocker):
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{LOCAL_REPOSITORY.key}",

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -68,7 +68,7 @@ def test_create_local_repository_using_create_repo_fail_if_user_already_exists(m
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(LOCAL_REPOSITORY)
 
-    artifactory_repo.create_local_repo.assert_called_once_with(LOCAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(LOCAL_REPOSITORY)
 
 
 @responses.activate
@@ -104,7 +104,7 @@ def test_create_virtual_repository_using_create_repo_fail_if_user_already_exists
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
 
-    artifactory_repo.create_virtual_repo.assert_called_once_with(VIRTUAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(VIRTUAL_REPOSITORY)
 
 
 @responses.activate
@@ -138,7 +138,7 @@ def test_create_remote_repository_using_create_repo_fail_if_user_already_exists(
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(REMOTE_REPOSITORY)
 
-    artifactory_repo.create_remote_repo.assert_called_once_with(REMOTE_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY)
 
 
 @responses.activate
@@ -178,9 +178,10 @@ def test_create_local_repository_using_create_repo_success(mocker):
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "create_local_repo")
-    local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
+    with pytest.raises(RepositoryNotFoundException):
+        local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
 
-    artifactory_repo.create_local_repo.assert_called_with(LOCAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_with(LOCAL_REPOSITORY.key)
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
 
@@ -231,9 +232,10 @@ def test_create_virtual_repository_using_create_repo_success(mocker):
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "create_virtual_repo")
-    virtual_repo = artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
+    with pytest.raises(RepositoryNotFoundException):
+        virtual_repo = artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
 
-    artifactory_repo.create_virtual_repo.assert_called_with(VIRTUAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_with(VIRTUAL_REPOSITORY.key)
     assert virtual_repo == VIRTUAL_REPOSITORY_RESPONSE
 
 
@@ -284,9 +286,10 @@ def test_create_remote_repository_using_create_repo_success(mocker):
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "create_remote_repo")
-    remote_repo = artifactory_repo.create_repo(REMOTE_REPOSITORY)
+    with pytest.raises(RepositoryNotFoundException):
+        remote_repo = artifactory_repo.create_repo(REMOTE_REPOSITORY)
 
-    artifactory_repo.create_remote_repo.assert_called_with(REMOTE_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_with(REMOTE_REPOSITORY.key)
     assert remote_repo == REMOTE_REPOSITORY_RESPONSE
 
 
@@ -405,7 +408,6 @@ def test_get_local_repository_using_get_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_local_repo")
     local_repo = artifactory_repo.get_repo(LOCAL_REPOSITORY.key)
 
-    artifactory_repo.get_local_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
 
@@ -439,7 +441,6 @@ def test_get_virtual_repository_using_get_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_virtual_repo")
     virtual_repo = artifactory_repo.get_repo(VIRTUAL_REPOSITORY.key)
 
-    artifactory_repo.get_virtual_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
     assert virtual_repo == VIRTUAL_REPOSITORY_RESPONSE
 
 
@@ -473,7 +474,6 @@ def test_get_remote_repository_using_get_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_remote_repo")
     remote_repo = artifactory_repo.get_repo(REMOTE_REPOSITORY.key)
 
-    artifactory_repo.get_remote_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
     assert remote_repo == REMOTE_REPOSITORY_RESPONSE
 
 
@@ -521,7 +521,7 @@ def test_update_local_repository_using_update_repo_fail_if_repo_not_found(mocker
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_repo(LOCAL_REPOSITORY)
 
-        artifactory_repo.update_local_repo.assert_called_once_with(LOCAL_REPOSITORY)
+        artifactory_repo.get_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -549,7 +549,7 @@ def test_update_virtual_repository_using_update_repo_fail_if_repo_not_found(mock
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_repo(VIRTUAL_REPOSITORY)
 
-        artifactory_repo.update_virtual_repo.assert_called_once_with(VIRTUAL_REPOSITORY)
+        artifactory_repo.get_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -579,7 +579,7 @@ def test_update_remote_repository_using_update_repo_fail_if_repo_not_found(mocke
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_repo(REMOTE_REPOSITORY)
 
-        artifactory_repo.update_remote_repo.assert_called_once_with(REMOTE_REPOSITORY)
+        artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
 
 
 @responses.activate
@@ -620,7 +620,7 @@ def test_update_local_repository_using_update_repo_success(mocker):
     mocker.spy(artifactory_repo, "update_local_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_LOCAL_REPOSITORY)
 
-    artifactory_repo.update_local_repo.assert_called_once_with(UPDATED_LOCAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(UPDATED_LOCAL_REPOSITORY.key)
     assert updated_repo == UPDATED_LOCAL_REPOSITORY_RESPONSE
 
 
@@ -671,9 +671,7 @@ def test_update_virtual_repository_using_update_repo_success(mocker):
     mocker.spy(artifactory_repo, "update_virtual_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_VIRTUAL_REPOSITORY)
 
-    artifactory_repo.update_virtual_repo.assert_called_once_with(
-        UPDATED_VIRTUAL_REPOSITORY
-    )
+    artifactory_repo.get_repo.assert_called_once_with(UPDATED_VIRTUAL_REPOSITORY.key)
     assert updated_repo == UPDATED_VIRTUAL_REPOSITORY_RESPONSE
 
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -55,7 +55,9 @@ UPDATED_REMOTE_REPOSITORY_RESPONSE = RemoteRepositoryResponse(
 
 
 @responses.activate
-def test_create_local_repository_using_create_repo_fail_if_user_already_exists(mocker):
+def test_create_local_repository_using_create_repo_fail_if_repository_already_exists(
+    mocker,
+):
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{LOCAL_REPOSITORY.key}",
@@ -64,15 +66,15 @@ def test_create_local_repository_using_create_repo_fail_if_user_already_exists(m
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "create_local_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(LOCAL_REPOSITORY)
 
-    artifactory_repo.get_repo.assert_called_once_with(LOCAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
-def test_create_local_repository_fail_if_user_already_exists(mocker):
+def test_create_local_repository_fail_if_repository_already_exists(mocker):
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{LOCAL_REPOSITORY.key}",
@@ -89,7 +91,7 @@ def test_create_local_repository_fail_if_user_already_exists(mocker):
 
 
 @responses.activate
-def test_create_virtual_repository_using_create_repo_fail_if_user_already_exists(
+def test_create_virtual_repository_using_create_repo_fail_if_repository_already_exists(
     mocker,
 ):
     responses.add(
@@ -100,15 +102,15 @@ def test_create_virtual_repository_using_create_repo_fail_if_user_already_exists
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "create_virtual_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
 
-    artifactory_repo.get_repo.assert_called_once_with(VIRTUAL_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
 
 
 @responses.activate
-def test_create_virtual_repository_fail_if_user_already_exists(mocker):
+def test_create_virtual_repository_fail_if_repository_already_exists(mocker):
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{VIRTUAL_REPOSITORY.key}",
@@ -125,7 +127,9 @@ def test_create_virtual_repository_fail_if_user_already_exists(mocker):
 
 
 @responses.activate
-def test_create_remote_repository_using_create_repo_fail_if_user_already_exists(mocker):
+def test_create_remote_repository_using_create_repo_fail_if_repository_already_exists(
+    mocker,
+):
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{REMOTE_REPOSITORY.key}",
@@ -134,15 +138,15 @@ def test_create_remote_repository_using_create_repo_fail_if_user_already_exists(
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "create_remote_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryAlreadyExistsException):
         artifactory_repo.create_repo(REMOTE_REPOSITORY)
 
-    artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY)
+    artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
 
 
 @responses.activate
-def test_create_remote_repository_fail_if_user_already_exists(mocker):
+def test_create_remote_repository_fail_if_repository_already_exists(mocker):
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{REMOTE_REPOSITORY.key}",
@@ -177,11 +181,10 @@ def test_create_local_repository_using_create_repo_success(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "create_local_repo")
-    with pytest.raises(RepositoryNotFoundException):
-        local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
+    mocker.spy(artifactory_repo, "get_repo")
+    local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
+    artifactory_repo.get_repo.side_effect = RepositoryNotFoundException
 
-    artifactory_repo.get_repo.assert_called_with(LOCAL_REPOSITORY.key)
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
 
@@ -231,11 +234,10 @@ def test_create_virtual_repository_using_create_repo_success(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "create_virtual_repo")
-    with pytest.raises(RepositoryNotFoundException):
-        virtual_repo = artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
+    mocker.spy(artifactory_repo, "get_repo")
+    virtual_repo = artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
+    artifactory_repo.get_repo.side_effect = RepositoryNotFoundException
 
-    artifactory_repo.get_repo.assert_called_with(VIRTUAL_REPOSITORY.key)
     assert virtual_repo == VIRTUAL_REPOSITORY_RESPONSE
 
 
@@ -285,11 +287,10 @@ def test_create_remote_repository_using_create_repo_success(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "create_remote_repo")
-    with pytest.raises(RepositoryNotFoundException):
-        remote_repo = artifactory_repo.create_repo(REMOTE_REPOSITORY)
+    mocker.spy(artifactory_repo, "get_repo")
+    remote_repo = artifactory_repo.create_repo(REMOTE_REPOSITORY)
+    artifactory_repo.get_repo.side_effect = RepositoryNotFoundException
 
-    artifactory_repo.get_repo.assert_called_with(REMOTE_REPOSITORY.key)
     assert remote_repo == REMOTE_REPOSITORY_RESPONSE
 
 
@@ -327,11 +328,9 @@ def test_get_local_repository_using_get_repo_error_not_found(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "get_local_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.get_repo(LOCAL_REPOSITORY.key)
-
-        artifactory_repo.get_local_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -346,20 +345,6 @@ def test_get_local_repository_error_not_found():
 
 
 @responses.activate
-def test_get_virtual_repository_using_get_repo_error_not_found(mocker):
-    responses.add(
-        responses.GET, f"{URL}/api/repositories/{VIRTUAL_REPOSITORY.key}", status=404
-    )
-
-    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "get_virtual_repo")
-    with pytest.raises(RepositoryNotFoundException):
-        artifactory_repo.get_repo(VIRTUAL_REPOSITORY.key)
-
-        artifactory_repo.get_virtual_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
-
-
-@responses.activate
 def test_get_virtual_repository_error_not_found():
     responses.add(
         responses.GET, f"{URL}/api/repositories/{VIRTUAL_REPOSITORY.key}", status=404
@@ -368,20 +353,6 @@ def test_get_virtual_repository_error_not_found():
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.get_virtual_repo(VIRTUAL_REPOSITORY.key)
-
-
-@responses.activate
-def test_get_remote_repository_using_get_repo_error_not_found(mocker):
-    responses.add(
-        responses.GET, f"{URL}/api/repositories/{REMOTE_REPOSITORY.key}", status=404
-    )
-
-    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "get_remote_repo")
-    with pytest.raises(RepositoryNotFoundException):
-        artifactory_repo.get_repo(REMOTE_REPOSITORY.key)
-
-        artifactory_repo.get_remote_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -396,7 +367,7 @@ def test_get_remote_repository_error_not_found():
 
 
 @responses.activate
-def test_get_local_repository_using_get_repo_success(mocker):
+def test_get_local_repository_using_get_repo_success():
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{LOCAL_REPOSITORY.key}",
@@ -405,7 +376,6 @@ def test_get_local_repository_using_get_repo_success(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "get_local_repo")
     local_repo = artifactory_repo.get_repo(LOCAL_REPOSITORY.key)
 
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
@@ -438,7 +408,6 @@ def test_get_virtual_repository_using_get_repo_success(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "get_virtual_repo")
     virtual_repo = artifactory_repo.get_repo(VIRTUAL_REPOSITORY.key)
 
     assert virtual_repo == VIRTUAL_REPOSITORY_RESPONSE
@@ -462,7 +431,7 @@ def test_get_virtual_repository_success(mocker):
 
 
 @responses.activate
-def test_get_remote_repository_using_get_repo_success(mocker):
+def test_get_remote_repository_using_get_repo_success():
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{REMOTE_REPOSITORY.key}",
@@ -471,7 +440,6 @@ def test_get_remote_repository_using_get_repo_success(mocker):
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "get_remote_repo")
     remote_repo = artifactory_repo.get_repo(REMOTE_REPOSITORY.key)
 
     assert remote_repo == REMOTE_REPOSITORY_RESPONSE
@@ -517,11 +485,10 @@ def test_update_local_repository_using_update_repo_fail_if_repo_not_found(mocker
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "update_local_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_repo(LOCAL_REPOSITORY)
-
-        artifactory_repo.get_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
+    artifactory_repo.get_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -535,7 +502,7 @@ def test_update_local_repository_fail_if_repo_not_found(mocker):
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_local_repo(LOCAL_REPOSITORY)
 
-        artifactory_repo.get_local_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
+    artifactory_repo.get_local_repo.assert_called_once_with(LOCAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -545,11 +512,11 @@ def test_update_virtual_repository_using_update_repo_fail_if_repo_not_found(mock
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "update_virtual_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_repo(VIRTUAL_REPOSITORY)
 
-        artifactory_repo.get_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
+    artifactory_repo.get_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -563,9 +530,7 @@ def test_update_virtual_repository_fail_if_repo_not_found(mocker):
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_virtual_repo(VIRTUAL_REPOSITORY)
 
-        artifactory_repo.get_virtual_repo.assert_called_once_with(
-            VIRTUAL_REPOSITORY.key
-        )
+    artifactory_repo.get_virtual_repo.assert_called_once_with(VIRTUAL_REPOSITORY.key)
 
 
 @responses.activate
@@ -575,11 +540,11 @@ def test_update_remote_repository_using_update_repo_fail_if_repo_not_found(mocke
     )
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "update_remote_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_repo(REMOTE_REPOSITORY)
 
-        artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
+    artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
 
 
 @responses.activate
@@ -593,7 +558,7 @@ def test_update_remote_repository_fail_if_repo_not_found(mocker):
     with pytest.raises(RepositoryNotFoundException):
         artifactory_repo.update_remote_repo(REMOTE_REPOSITORY)
 
-        artifactory_repo.get_remote_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
+    artifactory_repo.get_remote_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
 
 
 @responses.activate
@@ -617,10 +582,9 @@ def test_update_local_repository_using_update_repo_success(mocker):
         status=200,
     )
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "update_local_repo")
+    mocker.spy(artifactory_repo, "get_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_LOCAL_REPOSITORY)
 
-    artifactory_repo.get_repo.assert_called_once_with(UPDATED_LOCAL_REPOSITORY.key)
     assert updated_repo == UPDATED_LOCAL_REPOSITORY_RESPONSE
 
 
@@ -648,7 +612,7 @@ def test_update_local_repository_success(mocker):
 
 
 @responses.activate
-def test_update_virtual_repository_using_update_repo_success(mocker):
+def test_update_virtual_repository_using_update_repo_success():
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{UPDATED_VIRTUAL_REPOSITORY.key}",
@@ -668,10 +632,7 @@ def test_update_virtual_repository_using_update_repo_success(mocker):
         status=200,
     )
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "update_virtual_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_VIRTUAL_REPOSITORY)
-
-    artifactory_repo.get_repo.assert_called_once_with(UPDATED_VIRTUAL_REPOSITORY.key)
     assert updated_repo == UPDATED_VIRTUAL_REPOSITORY_RESPONSE
 
 
@@ -696,7 +657,7 @@ def test_update_virtual_repository_success(mocker):
 
 
 @responses.activate
-def test_update_remote_repository_using_update_repo_success(mocker):
+def test_update_remote_repository_using_update_repo_success():
     responses.add(
         responses.GET,
         f"{URL}/api/repositories/{UPDATED_REMOTE_REPOSITORY.key}",
@@ -716,12 +677,7 @@ def test_update_remote_repository_using_update_repo_success(mocker):
         status=200,
     )
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory_repo, "update_remote_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_REMOTE_REPOSITORY)
-
-    artifactory_repo.update_remote_repo.assert_called_once_with(
-        UPDATED_REMOTE_REPOSITORY
-    )
     assert updated_repo == UPDATED_REMOTE_REPOSITORY_RESPONSE
 
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -183,7 +183,6 @@ def test_create_local_repository_using_create_repo_success(mocker):
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "get_repo")
     local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
-    artifactory_repo.get_repo.side_effect = RepositoryNotFoundException
 
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
@@ -236,7 +235,6 @@ def test_create_virtual_repository_using_create_repo_success(mocker):
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "get_repo")
     virtual_repo = artifactory_repo.create_repo(VIRTUAL_REPOSITORY)
-    artifactory_repo.get_repo.side_effect = RepositoryNotFoundException
 
     assert virtual_repo == VIRTUAL_REPOSITORY_RESPONSE
 
@@ -289,7 +287,6 @@ def test_create_remote_repository_using_create_repo_success(mocker):
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "get_repo")
     remote_repo = artifactory_repo.create_repo(REMOTE_REPOSITORY)
-    artifactory_repo.get_repo.side_effect = RepositoryNotFoundException
 
     assert remote_repo == REMOTE_REPOSITORY_RESPONSE
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -216,9 +216,10 @@ def test_get_local_repository_success(mocker):
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "get_local_repo")
-    artifactory_repo.get_local_repo(LOCAL_REPOSITORY.key)
+    local_repo = artifactory_repo.get_local_repo(LOCAL_REPOSITORY.key)
 
     artifactory_repo.get_local_repo.assert_called_once()
+    assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
 
 @responses.activate
@@ -232,9 +233,10 @@ def test_get_virtual_repository_success(mocker):
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "get_virtual_repo")
-    artifactory_repo.get_virtual_repo(VIRTUAL_REPOSITORY.key)
+    virtual_repo = artifactory_repo.get_virtual_repo(VIRTUAL_REPOSITORY.key)
 
     artifactory_repo.get_virtual_repo.assert_called_once()
+    assert virtual_repo == VIRTUAL_REPOSITORY_RESPONSE
 
 
 @responses.activate
@@ -248,9 +250,10 @@ def test_get_remote_repository_success(mocker):
 
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     mocker.spy(artifactory_repo, "get_remote_repo")
-    artifactory_repo.get_remote_repo(REMOTE_REPOSITORY.key)
+    remote_repo = artifactory_repo.get_remote_repo(REMOTE_REPOSITORY.key)
 
     artifactory_repo.get_remote_repo.assert_called_once()
+    assert remote_repo == REMOTE_REPOSITORY_RESPONSE
 
 
 @responses.activate


### PR DESCRIPTION
## Description

Currently, depending of the repository type (local, virtual or remote), we have to use a specific methods **(get_local_repo, get_virtual_repo, update_remote_repo ...)**. This PR proposes global methods **(get_repo, create-repo, update_repo)** that do not bother anymore with the repo type.

Fixes #45 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)