### PR TITLE
Fix properties method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Repository](#repository)
     + [Permission](#permission)
   * [Artifacts](#artifacts)
+    + [Get the information about a file or folder](#get-the-information-about-a-file-or-folder)
     + [Deploy an artifact](#deploy-an-artifact)
     + [Download an artifact](#download-an-artifact)
     + [Retrieve artifact properties](#retrieve-artifact-properties)
@@ -261,6 +262,13 @@ art.permissions.delete("test_permission")
 ```
 
 ### Artifacts
+
+#### Get the information about a file or folder
+```python
+artifact_info = art.artifacts.info("<ARTIFACT_PATH_IN_ARTIFACTORY>")
+# file_info = art.artifacts.info("my-repository/my/artifact/directory/file.txt")
+# folder_info = art.artifacts.info("my-repository/my/artifact/directory")
+```
 
 #### Deploy an artifact
 ```python

--- a/README.md
+++ b/README.md
@@ -286,16 +286,16 @@ artifact = art.artifacts.download("<ARTIFACT_PATH_IN_ARTIFACTORY>", "<LOCAL_DIRE
 
 #### Retrieve artifact properties
 ```python
-artifact_properties = art.artifacts.properties("<ARTIFACT_PATH_IN_ARTIFACTORY>")
+artifact_properties = art.artifacts.properties("<ARTIFACT_PATH_IN_ARTIFACTORY>")  # returns all properties
 # artifact_properties = art.artifacts.properties("my-repository/my/new/artifact/directory/file.txt")
->>> print(artifact_properties.json)
+artifact_properties = art.artifacts.properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", ["prop1", "prop2"])  # returns specific properties
+artifact_properties.properties["prop1"]  # ["value1", "value1-bis"]
 ```
 
 #### Retrieve artifact stats
 ```python
 artifact_stats = art.artifacts.stats("<ARTIFACT_PATH_IN_ARTIFACTORY>")
 # artifact_stats = art.artifacts.stats("my-repository/my/new/artifact/directory/file.txt")
->>> print(artifact_stats.json)
 ```
 
 #### Copy artifact to a new location

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,12 @@
 [mypy]
+files = pyartifactory
 plugins = pydantic.mypy
 warn_return_any = True
 warn_unused_configs = True
+pretty = True
 
 [mypy-requests_toolbelt.multipart]
 ignore_missing_imports = True
+
+[pydantic-mypy]
+init_forbid_extra = True

--- a/pyartifactory/exception.py
+++ b/pyartifactory/exception.py
@@ -39,5 +39,9 @@ class PermissionNotFoundException(ArtifactoryException):
     """A permission object was not found."""
 
 
+class PropertyNotFoundException(ArtifactoryException):
+    """All requested properties were not found"""
+
+
 class InvalidTokenDataException(ArtifactoryException):
     """The token contains invalid data."""

--- a/pyartifactory/exception.py
+++ b/pyartifactory/exception.py
@@ -39,6 +39,10 @@ class PermissionNotFoundException(ArtifactoryException):
     """A permission object was not found."""
 
 
+class ArtifactNotFoundException(ArtifactoryException):
+    """An artifact was not found"""
+
+
 class PropertyNotFoundException(ArtifactoryException):
     """All requested properties were not found"""
 

--- a/pyartifactory/models/__init__.py
+++ b/pyartifactory/models/__init__.py
@@ -1,7 +1,7 @@
 """
 Import all models here.
 """
-from typing import Union
+from typing import Union, Type
 
 from .auth import AuthModel, ApiKeyModel, PasswordModel, AccessTokenModel
 from .group import Group, SimpleGroup
@@ -16,7 +16,13 @@ from .repository import (
     SimpleRepository,
 )
 
-from .artifact import ArtifactPropertiesResponse, ArtifactStatsResponse
+from .artifact import (
+    ArtifactPropertiesResponse,
+    ArtifactStatsResponse,
+    ArtifactFileInfoResponse,
+    ArtifactFolderInfoResponse,
+    ArtifactInfoResponse,
+)
 from .permission import Permission, SimplePermission
 
 

--- a/pyartifactory/models/artifact.py
+++ b/pyartifactory/models/artifact.py
@@ -4,7 +4,7 @@ Definition of all artifact models.
 
 
 from datetime import datetime
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union
 from pydantic import BaseModel
 
 
@@ -26,34 +26,44 @@ class Child(BaseModel):
     """Models a child folder."""
 
     uri: str
-    folder: str
+    folder: bool
 
 
 class ArtifactPropertiesResponse(BaseModel):
-    """ Models an artifact properties response"""
+    """ Models an artifact properties response."""
 
     uri: str
     properties: Dict[str, List[str]]
 
 
-class ArtifactFileInfoResponse(BaseModel):
-    """Models an artifact file info response."""
+class ArtifactInfoResponseBase(BaseModel):
+    """The base information available for both file and folder"""
 
     repo: str
     path: str
     created: Optional[datetime] = None
-    createdBy: str
+    createdBy: Optional[str] = None
     lastModified: Optional[datetime] = None
     modifiedBy: Optional[str] = None
     lastUpdated: Optional[datetime] = None
+    uri: str
+
+
+class ArtifactFolderInfoResponse(ArtifactInfoResponseBase):
+    """Models an artifact folder info response."""
+
+    children: List[Child]
+
+
+class ArtifactFileInfoResponse(ArtifactInfoResponseBase):
+    """Models an artifact file info response."""
+
     downloadUri: Optional[str] = None
     remoteUrl: Optional[str] = None
     mimeType: Optional[str] = None
-    size: Optional[str] = None
+    size: Optional[int] = None
     checksums: Optional[Checksums] = None
     originalChecksums: Optional[OriginalChecksums] = None
-    children: Optional[List[Child]] = None
-    uri: str
 
 
 class ArtifactStatsResponse(BaseModel):
@@ -65,3 +75,6 @@ class ArtifactStatsResponse(BaseModel):
     lastDownloadedBy: Optional[str]
     remoteDownloadCount: int
     remoteLastDownloaded: int
+
+
+ArtifactInfoResponse = Union[ArtifactFileInfoResponse, ArtifactFolderInfoResponse]

--- a/pyartifactory/models/artifact.py
+++ b/pyartifactory/models/artifact.py
@@ -4,7 +4,7 @@ Definition of all artifact models.
 
 
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Dict
 from pydantic import BaseModel
 
 
@@ -30,6 +30,11 @@ class Child(BaseModel):
 
 
 class ArtifactPropertiesResponse(BaseModel):
+    uri: str
+    properties: Dict[str, List[str]]
+
+
+class ArtifactFileInfoResponse(BaseModel):
     """Models an artifact properties response."""
 
     repo: str

--- a/pyartifactory/models/artifact.py
+++ b/pyartifactory/models/artifact.py
@@ -30,12 +30,14 @@ class Child(BaseModel):
 
 
 class ArtifactPropertiesResponse(BaseModel):
+    """ Models an artifact properties response"""
+
     uri: str
     properties: Dict[str, List[str]]
 
 
 class ArtifactFileInfoResponse(BaseModel):
-    """Models an artifact properties response."""
+    """Models an artifact file info response."""
 
     repo: str
     path: str

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -775,7 +775,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
 
     def deploy(
         self, local_file_location: str, artifact_path: str
-    ) -> ArtifactPropertiesResponse:
+    ) -> ArtifactInfoResponse:
         """
         :param artifact_path: Path to file in Artifactory
         :param local_file_location: Location of the file to deploy
@@ -792,7 +792,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             headers = {"Prefer": "respond-async", "Content-Type": form.content_type}
             self._put(f"{artifact_path}", headers=headers, data=form)
             logger.debug("Artifact %s successfully deployed", local_filename)
-            return self.properties(artifact_path)
+            return self.info(artifact_path)
 
     def download(self, artifact_path: str, local_directory_path: str = None) -> str:
         """
@@ -854,12 +854,12 @@ class ArtifactoryArtifact(ArtifactoryObject):
 
     def copy(
         self, artifact_current_path: str, artifact_new_path: str, dryrun: bool = False
-    ) -> ArtifactPropertiesResponse:
+    ) -> ArtifactInfoResponse:
         """
         :param artifact_current_path: Current path to file
         :param artifact_new_path: New path to file
         :param dryrun: Dry run
-        :return: ArtifactPropertiesResponse: properties of the copied artifact
+        :return: ArtifactInfoResponse: info of the copied artifact
         """
         artifact_current_path = artifact_current_path.lstrip("/")
         artifact_new_path = artifact_new_path.lstrip("/")
@@ -870,16 +870,16 @@ class ArtifactoryArtifact(ArtifactoryObject):
 
         self._post(f"api/copy/{artifact_current_path}?to={artifact_new_path}&dry={dry}")
         logger.debug("Artifact %s successfully copied", artifact_current_path)
-        return self.properties(artifact_new_path)
+        return self.info(artifact_new_path)
 
     def move(
         self, artifact_current_path: str, artifact_new_path: str, dryrun: bool = False
-    ) -> ArtifactPropertiesResponse:
+    ) -> ArtifactInfoResponse:
         """
         :param artifact_current_path: Current path to file
         :param artifact_new_path: New path to file
         :param dryrun: Dry run
-        :return: ArtifactPropertiesResponse: properties of the moved artifact
+        :return: ArtifactInfoResponse: info of the moved artifact
         """
         artifact_current_path = artifact_current_path.lstrip("/")
         artifact_new_path = artifact_new_path.lstrip("/")
@@ -891,7 +891,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
 
         self._post(f"api/move/{artifact_current_path}?to={artifact_new_path}&dry={dry}")
         logger.debug("Artifact %s successfully moved", artifact_current_path)
-        return self.properties(artifact_new_path)
+        return self.info(artifact_new_path)
 
     def delete(self, artifact_path: str) -> None:
         """

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -57,11 +57,7 @@ class Artifactory:
     """Models artifactory."""
 
     def __init__(
-        self,
-        url: str,
-        auth: Tuple[str, str] = None,
-        verify: bool = True,
-        cert: str = None,
+        self, url: str, auth: Tuple[str, str], verify: bool = True, cert: str = None,
     ):
         self.artifactory = AuthModel(url=url, auth=auth, verify=verify, cert=cert)
         self.users = ArtifactoryUser(self.artifactory)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -107,16 +107,16 @@ def test_deploy_artifact_success(mocker):
 
     responses.add(
         responses.GET,
-        f"{URL}/api/storage/{ARTIFACT_PATH}?properties[=x[,y]]",
-        json=ARTIFACT_PROPERTIES.dict(),
+        f"{URL}/api/storage/{ARTIFACT_PATH}",
+        json=FILE_INFO_RESPONSE,
         status=200,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    mocker.spy(artifactory, "properties")
+    mocker.spy(artifactory, "info")
     artifact = artifactory.deploy(LOCAL_FILE_LOCATION, ARTIFACT_PATH)
 
-    artifactory.properties.assert_called_once_with(ARTIFACT_PATH)
-    assert artifact.dict() == ARTIFACT_PROPERTIES.dict()
+    artifactory.info.assert_called_once_with(ARTIFACT_PATH)
+    assert artifact.dict() == FILE_INFO.dict()
 
 
 @responses.activate
@@ -228,14 +228,14 @@ def test_copy_artifact_success():
     )
     responses.add(
         responses.GET,
-        f"{URL}/api/storage/{ARTIFACT_NEW_PATH}?properties[=x[,y]]",
+        f"{URL}/api/storage/{ARTIFACT_NEW_PATH}",
         status=200,
-        json=NEW_ARTIFACT_PROPERTIES.dict(),
+        json=FILE_INFO_RESPONSE,
     )
 
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     artifact_copied = artifactory.copy(ARTIFACT_PATH, ARTIFACT_NEW_PATH)
-    assert artifact_copied.dict() == NEW_ARTIFACT_PROPERTIES.dict()
+    assert artifact_copied.dict() == FILE_INFO.dict()
 
 
 @responses.activate
@@ -247,14 +247,14 @@ def test_move_artifact_success():
     )
     responses.add(
         responses.GET,
-        f"{URL}/api/storage/{ARTIFACT_NEW_PATH}?properties[=x[,y]]",
+        f"{URL}/api/storage/{ARTIFACT_NEW_PATH}",
         status=200,
-        json=NEW_ARTIFACT_PROPERTIES.dict(),
+        json=FILE_INFO_RESPONSE,
     )
 
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     artifact_moved = artifactory.move(ARTIFACT_PATH, ARTIFACT_NEW_PATH)
-    assert artifact_moved.dict() == NEW_ARTIFACT_PROPERTIES.dict()
+    assert artifact_moved.dict() == FILE_INFO.dict()
 
 
 @responses.activate


### PR DESCRIPTION
## Description

Fix `artifacts.properties()` method, and add a `artifacts.info()` method that returns what the old `.properties()` returned.

Fixes #50

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has it been tested ?

Unit tests have been added for the fixed `.properties()` method, for the new `.info()`, and fixed for methods depending on the old `.properties()` behavior.


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
