### PR TITLE
fix: do not send read-only attributes when updating user

### DIFF
--- a/pyartifactory/models/user.py
+++ b/pyartifactory/models/user.py
@@ -16,7 +16,10 @@ class SimpleUser(BaseModel):
 
 
 class BaseUserModel(BaseModel):
-    """Models a base user."""
+    """
+    Models a base user.
+    https://www.jfrog.com/confluence/display/JFROG/Security+Configuration+JSON#SecurityConfigurationJSON-application/vnd.org.jfrog.artifactory.security.User+json
+    """
 
     name: str
     admin: Optional[bool] = False

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -198,7 +198,10 @@ class ArtifactoryUser(ArtifactoryObject):
         """
         username = user.name
         self.get(username)
-        self._post(f"api/{self._uri}/{username}", json=user.dict())
+        self._post(
+            f"api/{self._uri}/{username}",
+            json=user.dict(exclude={"lastLoggedIn", "realm"}),
+        )
         logger.debug("User %s successfully updated", username)
         return self.get(username)
 


### PR DESCRIPTION
## Description

Some attributes (such as `lastLoggedIn` or `realm`) are read-only, so we
don't need to send them back. It also fixes #57 indirectly, because we
don't try to serialize the date anymore.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [ ] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
