### PR TITLE
Add support for recursive up- and downloads

### DIFF
--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -849,7 +849,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         logger.debug("Artifact %s successfully downloaded", local_filename)
         return local_file_full_path
 
-    def download(self, artifact_path: str, local_directory_path: str = None) -> str:
+    def download(self, artifact_path: str, local_directory_path: str = ".") -> str:
         """
         Download artifact (file or directory) into local directory.
         :param artifact_path: Path to file or directory in Artifactory
@@ -858,20 +858,15 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.rstrip("/")
         basename = artifact_path.split("/")[-1]
-        if local_directory_path:
-            local_file_full_path = f"{local_directory_path}/{basename}"
-        else:
-            local_file_full_path = basename
         prefix = artifact_path.rsplit("/", 1)[0] + "/" if "/" in artifact_path else ""
         for art in self._walk(artifact_path):
             full_path = art.repo + art.path
-            # assert full_path.startswith(prefix)
-            local_path = join(local_directory_path, full_path[len(prefix) :])  # type: ignore[arg-type]
+            local_path = join(local_directory_path, full_path[len(prefix) :])
             if isinstance(art, ArtifactFolderInfoResponse):
                 os.mkdir(local_path)
             else:
                 self._download(art.repo + art.path, local_path.rsplit("/", 1)[0])
-        return local_file_full_path
+        return f"{local_directory_path}/{basename}"
 
     def properties(
         self, artifact_path: str, properties: Optional[List[str]] = None

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -15,8 +15,8 @@ from pyartifactory.models.artifact import (
 
 URL = "http://localhost:8080/artifactory"
 AUTH = ("user", "password_or_apiKey")
-ARTIFACT_FOLDER = "my_repository"
-ARTIFACT_PATH = f"{ARTIFACT_FOLDER}/file.txt"
+ARTIFACT_REPO = "my_repository"
+ARTIFACT_PATH = f"{ARTIFACT_REPO}/file.txt"
 ARTIFACT_NEW_PATH = "my-second-repository/file.txt"
 ARTIFACT_SHORT_PATH = "/file.txt"
 LOCAL_FILE_LOCATION = "tests/test_artifacts.py"
@@ -28,8 +28,8 @@ ARTIFACT_MULTIPLE_PROPERTIES = ArtifactPropertiesResponse(
     properties={"prop1": ["value"], "prop2": ["another value", "with multiple parts"]},
 )
 FOLDER_INFO_RESPONSE = {
-    "uri": f"{URL}/api/storage/{ARTIFACT_FOLDER}",
-    "repo": ARTIFACT_FOLDER,
+    "uri": f"{URL}/api/storage/{ARTIFACT_REPO}",
+    "repo": ARTIFACT_REPO,
     "path": "/",
     "created": "2019-06-06T13:19:14.514Z",
     "createdBy": "userY",
@@ -43,8 +43,8 @@ FOLDER_INFO_RESPONSE = {
 }
 FOLDER_INFO = ArtifactFolderInfoResponse(**FOLDER_INFO_RESPONSE)
 FILE_INFO_RESPONSE = {
-    "repo": ARTIFACT_FOLDER,
-    "path": ARTIFACT_PATH,
+    "repo": ARTIFACT_REPO,
+    "path": ARTIFACT_SHORT_PATH,
     "created": "2019-06-06T13:19:14.514Z",
     "createdBy": "userY",
     "lastModified": "2019-06-06T13:19:14.514Z",
@@ -78,12 +78,12 @@ ARTIFACT_STATS = ArtifactStatsResponse(
 def test_get_artifact_folder_info_success():
     responses.add(
         responses.GET,
-        f"{URL}/api/storage/{ARTIFACT_FOLDER}",
+        f"{URL}/api/storage/{ARTIFACT_REPO}",
         status=200,
         json=FOLDER_INFO_RESPONSE,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    artifact = artifactory.info(ARTIFACT_FOLDER)
+    artifact = artifactory.info(ARTIFACT_REPO)
     assert isinstance(artifact, ArtifactFolderInfoResponse)
     assert artifact.dict() == FOLDER_INFO.dict()
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -42,6 +42,16 @@ FOLDER_INFO_RESPONSE = {
     ],
 }
 FOLDER_INFO = ArtifactFolderInfoResponse(**FOLDER_INFO_RESPONSE)
+
+CHILD1_FOLDER_INFO_RESPONSE = FOLDER_INFO_RESPONSE.copy()
+CHILD1_FOLDER_INFO_RESPONSE["uri"] = f"{URL}/api/storage/{ARTIFACT_REPO}/child1"
+CHILD1_FOLDER_INFO_RESPONSE["path"] = "/child1"
+CHILD1_FOLDER_INFO_RESPONSE["children"] = [
+    {"uri": "/grandchild", "folder": "false"},
+]
+CHILD1_FOLDER_INFO = ArtifactFolderInfoResponse(**CHILD1_FOLDER_INFO_RESPONSE)
+
+
 FILE_INFO_RESPONSE = {
     "repo": ARTIFACT_REPO,
     "path": ARTIFACT_SHORT_PATH,
@@ -64,6 +74,17 @@ FILE_INFO_RESPONSE = {
     "uri": f"{URL}/api/storage/{ARTIFACT_PATH}",
 }
 FILE_INFO = ArtifactFileInfoResponse(**FILE_INFO_RESPONSE)
+
+CHILD2_INFO_RESPONSE = FILE_INFO_RESPONSE.copy()
+CHILD2_INFO_RESPONSE["uri"] = f"{URL}/api/storage/{ARTIFACT_REPO}/child2"
+CHILD2_INFO_RESPONSE["path"] = "/child2"
+CHILD2_FILE_INFO = ArtifactFileInfoResponse(**CHILD2_INFO_RESPONSE)
+
+GRANDCHILD_INFO_RESPONSE = FILE_INFO_RESPONSE.copy()
+GRANDCHILD_INFO_RESPONSE["uri"] = f"{URL}/api/storage/{ARTIFACT_REPO}/child1/grandchild"
+GRANDCHILD_INFO_RESPONSE["path"] = "/child1/grandchild"
+GRANDCHILD_FILE_INFO = ArtifactFileInfoResponse(**GRANDCHILD_INFO_RESPONSE)
+
 
 ARTIFACT_STATS = ArtifactStatsResponse(
     uri="my_uri",
@@ -123,6 +144,12 @@ def test_deploy_artifact_success(mocker):
 def test_download_artifact_success(tmp_path):
     artifact_name = ARTIFACT_PATH.split("/")[1]
     responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_PATH}",
+        status=200,
+        json=FILE_INFO_RESPONSE,
+    )
+    responses.add(
         responses.GET, f"{URL}/{ARTIFACT_PATH}", json=artifact_name, status=200
     )
 
@@ -131,6 +158,52 @@ def test_download_artifact_success(tmp_path):
 
     assert artifact == f"{tmp_path.resolve()}/{artifact_name}"
     assert (tmp_path / artifact_name).is_file()
+
+
+@responses.activate
+def test_download_folder_success(tmp_path):
+    # artifact_name = ARTIFACT_PATH.split("/")[1]
+    responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_REPO}",
+        status=200,
+        json=FOLDER_INFO_RESPONSE,
+    )
+    responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_REPO}/child1",
+        status=200,
+        json=CHILD1_FOLDER_INFO_RESPONSE,
+    )
+    responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_REPO}/child2",
+        status=200,
+        json=CHILD2_INFO_RESPONSE,
+    )
+    responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_REPO}/child1/grandchild",
+        status=200,
+        json=GRANDCHILD_INFO_RESPONSE,
+    )
+    responses.add(responses.GET, f"{URL}/{ARTIFACT_REPO}", json="/", status=200)
+    responses.add(
+        responses.GET,
+        f"{URL}/{ARTIFACT_REPO}/child1/grandchild",
+        json="/child1/grandchild",
+        status=200,
+    )
+    responses.add(
+        responses.GET, f"{URL}/{ARTIFACT_REPO}/child2", json="/child2", status=200
+    )
+
+    artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
+    artifact = artifactory.download(f"{ARTIFACT_REPO}/", str(tmp_path.resolve()))
+
+    assert artifact == f"{tmp_path.resolve()}/{ARTIFACT_REPO}"
+    assert (tmp_path / f"{ARTIFACT_REPO}" / "child1" / "grandchild").is_file()
+    assert (tmp_path / f"{ARTIFACT_REPO}" / "child2").is_file()
 
 
 @responses.activate


### PR DESCRIPTION
## Description

This PR allows the `art.artifacts.deploy()` and `art.artifacts.download()` methods to operate on directories recursively.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
        (one could argue that the existing docs don't explicitly talk about arguments types (file or directory),
         would it should at least be in the release notes)
## How has it been tested ?

I ran all existing tests (obviously), and added a new test (`test_artifacts.py::test_download_folder_success`)
to make sure downloading a directory work.

I did not add a new test to verify directory uploads.

## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [ ] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
