### PR TITLE
Removing SecretStr from RemoteRepository model

### DIFF
--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional, List
 from typing_extensions import Literal
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 
 
 class PackageTypeEnum(str, Enum):
@@ -224,7 +224,7 @@ class RemoteRepository(BaseRepositoryModel):
     rclass: Literal[RClassEnum.remote] = RClassEnum.remote
     url: str
     username: Optional[str] = None
-    password: Optional[SecretStr] = None
+    password: Optional[str] = None
     proxy: Optional[str] = None
     remoteRepoChecksumPolicyType: str = "generate-if-absent"
     handleReleases: bool = True

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional, List
 from typing_extensions import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class PackageTypeEnum(str, Enum):
@@ -224,7 +224,7 @@ class RemoteRepository(BaseRepositoryModel):
     rclass: Literal[RClassEnum.remote] = RClassEnum.remote
     url: str
     username: Optional[str] = None
-    password: Optional[str] = None
+    password: Optional[SecretStr] = None
     proxy: Optional[str] = None
     remoteRepoChecksumPolicyType: str = "generate-if-absent"
     handleReleases: bool = True

--- a/pyartifactory/utils.py
+++ b/pyartifactory/utils.py
@@ -1,0 +1,19 @@
+"""
+Definition of all utils.
+"""
+
+from typing import Any
+
+from pydantic import SecretStr
+from pydantic.json import pydantic_encoder
+
+
+def custom_encoder(obj: Any) -> Any:
+    """
+    Custom encoder function to be passed to the default argument of json.dumps()
+    :param obj: A pydantic object
+    :return: An encoded pydantic object
+    """
+    if isinstance(obj, SecretStr):
+        return obj.get_secret_value()
+    return pydantic_encoder(obj)


### PR DESCRIPTION
SecretStr is not JSON serializable and is throwing exceptions for RemoteRepositories that require a password.

## Description
I've been using this library to create repositories for my Artifactory Instance. I started adding a RemoteRepository for docker and came upon this error that states: "Object of type SecretStr is not JSON serializable"

## To Reproduce
Steps to reproduce the behavior:

```python
from pyartifactory import Artifactory
from pyartifactory.models import RemoteRepository

url = <url to artifactory instance>
auth = (<username>, <password>)
remote_docker_repo_cfg = {
    "key": "docker-remote",
    "url": "https://registry-1.docker.io/",
    "packageType": "docker",
    "username": <dockerhub username>,
    "password": <dockerhub_password>,
}
rt = Artifactory(url=url, auth=auth)
remote_repo = RemoteRepository(**remote_docker_repo_cfg)
rt.repositories.create_repo(remote_repo)
```

Fixes # https://github.com/anancarv/python-artifactory/issues/74
