### PR TITLE
fix: bug causing first char of path to disappear

### DIFF
--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -847,6 +847,18 @@ class ArtifactoryArtifact(ArtifactoryObject):
         logger.debug("Artifact %s successfully downloaded", local_filename)
         return local_file_full_path
 
+    @staticmethod
+    def _get_path_prefix(artifact_path: str):
+        if artifact_path.startswith("/"):
+            artifact_path = artifact_path[1:]
+        return artifact_path.rsplit("/", 1)[0] + "/" if "/" in artifact_path else ""
+
+    @staticmethod
+    def _remove_prefix(_str: str, prefix: str) -> str:
+        if _str.startswith(prefix):
+            return _str[len(prefix) :]
+        raise ValueError(f"Input string, '{_str}', doesn't have the prefix: '{prefix}'")
+
     def download(self, artifact_path: str, local_directory_path: str = ".") -> str:
         """
         Download artifact (file or directory) into local directory.
@@ -856,10 +868,10 @@ class ArtifactoryArtifact(ArtifactoryObject):
         """
         artifact_path = artifact_path.rstrip("/")
         basename = artifact_path.split("/")[-1]
-        prefix = artifact_path.rsplit("/", 1)[0] + "/" if "/" in artifact_path else ""
+        prefix = self._get_path_prefix(artifact_path)
         for art in self._walk(artifact_path):
             full_path = art.repo + art.path
-            local_artifact_path = full_path[len(prefix) :]
+            local_artifact_path = self._remove_prefix(full_path, prefix)
             local_path = Path(local_directory_path) / local_artifact_path
             if isinstance(art, ArtifactFolderInfoResponse):
                 os.makedirs(local_path, exist_ok=True)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -160,8 +160,12 @@ def test_download_artifact_success(tmp_path):
     assert (tmp_path / artifact_name).is_file()
 
 
+@pytest.mark.parametrize(
+    "requested_path",
+    [ARTIFACT_REPO, f"{ARTIFACT_REPO}/", f"/{ARTIFACT_REPO}", f"/{ARTIFACT_REPO}/"],
+)
 @responses.activate
-def test_download_folder_success(tmp_path):
+def test_download_folder_success(tmp_path, requested_path):
     # artifact_name = ARTIFACT_PATH.split("/")[1]
     responses.add(
         responses.GET,
@@ -199,7 +203,7 @@ def test_download_folder_success(tmp_path):
     )
 
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    artifact = artifactory.download(f"{ARTIFACT_REPO}/", str(tmp_path.resolve()))
+    artifact = artifactory.download(requested_path, str(tmp_path.resolve()))
 
     assert artifact == f"{tmp_path.resolve()}/{ARTIFACT_REPO}"
     assert (tmp_path / f"{ARTIFACT_REPO}" / "child1" / "grandchild").is_file()


### PR DESCRIPTION
## Description
If the artifact path started with forward-slash, "/", the
the local folder would miss the first character of the word.
e.g. /test would be saved as /est


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How has it been tested ?
- [X] Parametrizing the existing test for download path. This know tests multiple options for the artifactory path, beginning and ending slashes in the path.



## Checklist:

- [X] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [ ] All commits have a correct title
- [X] Readme has been updated
- [X] Quality tests are green (see Codacy)
- [X] Automated tests are green (see pipeline)
