### PR TITLE
feat: add overloading to create_repo & update_repo

### DIFF
--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from os.path import isdir, join
-from typing import List, Optional, Dict, Tuple, Union, Iterator
+from typing import List, Optional, Dict, Tuple, Union, Iterator, overload
 
 from pathlib import Path
 import requests
@@ -453,6 +453,18 @@ class ArtifactoryRepository(ArtifactoryObject):
                 )
             raise ArtifactoryException from error
 
+    @overload
+    def create_repo(self, repo: LocalRepository) -> LocalRepositoryResponse:
+        ...
+
+    @overload
+    def create_repo(self, repo: VirtualRepository) -> VirtualRepositoryResponse:
+        ...
+
+    @overload
+    def create_repo(self, repo: RemoteRepository) -> RemoteRepositoryResponse:
+        ...
+
     def create_repo(self, repo: AnyRepository) -> AnyRepositoryResponse:
         """
         Creates a local, virtual or remote repository
@@ -475,6 +487,18 @@ class ArtifactoryRepository(ArtifactoryObject):
             )
             logger.debug("Repository %s successfully created", repo_name)
             return self.get_repo(repo_name)
+
+    @overload
+    def update_repo(self, repo: LocalRepository) -> LocalRepositoryResponse:
+        ...
+
+    @overload
+    def update_repo(self, repo: VirtualRepository) -> VirtualRepositoryResponse:
+        ...
+
+    @overload
+    def update_repo(self, repo: RemoteRepository) -> RemoteRepositoryResponse:
+        ...
 
     def update_repo(self, repo: AnyRepository) -> AnyRepositoryResponse:
         """

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -184,6 +184,7 @@ def test_create_local_repository_using_create_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_repo")
     local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
 
+    assert type(local_repo) == LocalRepositoryResponse
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
 
@@ -582,6 +583,7 @@ def test_update_local_repository_using_update_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_LOCAL_REPOSITORY)
 
+    assert type(updated_repo) == LocalRepositoryResponse
     assert updated_repo == UPDATED_LOCAL_REPOSITORY_RESPONSE
 
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -184,7 +184,7 @@ def test_create_local_repository_using_create_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_repo")
     local_repo = artifactory_repo.create_repo(LOCAL_REPOSITORY)
 
-    assert type(local_repo) == LocalRepositoryResponse
+    assert isinstance(local_repo, LocalRepositoryResponse)
     assert local_repo == LOCAL_REPOSITORY_RESPONSE
 
 
@@ -583,7 +583,7 @@ def test_update_local_repository_using_update_repo_success(mocker):
     mocker.spy(artifactory_repo, "get_repo")
     updated_repo = artifactory_repo.update_repo(UPDATED_LOCAL_REPOSITORY)
 
-    assert type(updated_repo) == LocalRepositoryResponse
+    assert isinstance(updated_repo, LocalRepositoryResponse)
     assert updated_repo == UPDATED_LOCAL_REPOSITORY_RESPONSE
 
 


### PR DESCRIPTION
## Description

Improve the typing of the functions `create_repo` and `update_repo` by adding function overloading. This way, we can give to the same function multiple type annotations to more accurately describe the function's behavior.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has it been tested ?

- [x] https://github.com/anancarv/python-artifactory/blob/8f49592ca13270877b335459c8867bd8c20fd4e3/tests/test_repositories.py#L187
- [x] https://github.com/anancarv/python-artifactory/blob/8f49592ca13270877b335459c8867bd8c20fd4e3/tests/test_repositories.py#L586


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
