### PR TITLE
Correct member-of-groups usage for access tokens

### DIFF
--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -272,7 +272,7 @@ class ArtifactorySecurity(ArtifactoryObject):
         if groups:
             if not isinstance(groups, list):
                 raise ValueError(groups)
-            scope = f'member-of-groups:"{", ".join(groups)}"'
+            scope = f'member-of-groups:"{",".join(groups)}"'
             payload.update({"scope": scope})
         response = self._post(
             f"api/{self._uri}/token", data=payload, raise_for_status=False


### PR DESCRIPTION
The documentation suggests that group names can be ", " delimited.
This works for group names that does not contain spaces.

Group names with spaces are supported.
To support this we must quote the group list, as `pyartifactory` does.
This also requires us to change group delimiter to ",".
I would assume this is due to Artifactory not being able to destinguish
between the delimiter space and any potential group name spaces.

Correct by using "," in combination with quoting the list.
