### PR TITLE
Support Artifactory REST APIv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 
 
-`pyartifactory` is a Python library to access the [Artifactory REST API](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API). 
+`pyartifactory` is a Python library to access the [Artifactory REST API](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API).
 
 This library enables you to manage Artifactory resources such as users, groups, permissions, repositories, artifacts and access tokens in your applications. Based on Python 3.6+ type hints.
 
@@ -24,6 +24,8 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Security](#security)
     + [Repository](#repository)
     + [Permission](#permission)
+      - [Artifatctory 6.6.0 or higher](#artifatctory-660-or-higher)
+      - [Artifatctory lower than 6.6.0](#artifatctory-lower-than-660)
   * [Artifacts](#artifacts)
     + [Get the information about a file or folder](#get-the-information-about-a-file-or-folder)
     + [Deploy an artifact](#deploy-an-artifact)
@@ -45,16 +47,18 @@ This library enables you to manage Artifactory resources such as users, groups, 
 ## Install
 
 ```python
-pip install pyartifactory 
+pip install pyartifactory
 ```
 
 ## Usage
 
 ### Authentication
 
+Since Artifatctory 6.6.0 there is version 2 of the REST API for permission managmant, in case you have that version or higher, you need to pass api_version=2 to the constructor when you instantiate the calss.
+
 ```python
 from pyartifactory import Artifactory
-art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSWORD_OR_API_KEY'))
+art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSWORD_OR_API_KEY'), api_version=1)
 ```
 
 ### SSL Cert Verification Options
@@ -62,14 +66,14 @@ Specify a local cert to use as client side certificate
 
 ```python
 from pyartifactory import Artifactory
-art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSORD_OR_API_KEY'), cert="/path_to_file/server.pem")
+art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSORD_OR_API_KEY'), cert="/path_to_file/server.pem",api_version=1)
 ```
 
 Disable host cert verification
 
 ```python
 from pyartifactory import Artifactory
-art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSORD_OR_API_KEY'), verify=False)
+art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSORD_OR_API_KEY'), verify=False, api_version=1)
 ```
 
 ### Admin objects
@@ -167,14 +171,14 @@ art.security.get_api_key(             art.security.regenerate_api_key(      art.
 
 Create an access token (for a transient user):
 ```python
-token = art.security.create_access_token(user_name='transient_artifactory_user', 
+token = art.security.create_access_token(user_name='transient_artifactory_user',
                                          groups=['g1', 'g2'],
                                          refreshable=True)
 ```
 
 Create an access token for an existing user (groups are implied from the existing user):
 ```python
-token = art.security.create_access_token(user_name='existing_artifactory_user', 
+token = art.security.create_access_token(user_name='existing_artifactory_user',
                                          refreshable=True)
 ```
 
@@ -235,8 +239,50 @@ users = art.permissions.get("test_permission")
 ```
 
 Create/Update a permission:
+
+##### Artifatctory 6.6.0 or higher
 ```python
-from pyartifactory.models import Permission
+
+from pyartifactory.models import Permisson_v2
+
+# Create a permission
+permission = PermissionV2(
+    name="test_permission",
+    repo=RepoV2(
+        repositories=["test_repository"],
+        actions=PrincipalsPermissionV2(
+            users={
+                ""test_user"": [
+                    PermissionEnumV2.read,
+                    PermissionEnumV2.annotate,
+                    PermissionEnumV2.write,
+                    PermissionEnumV2.delete,
+                ]
+            },
+            groups={
+                "developers": [
+                    PermissionEnumV2.read,
+                    PermissionEnumV2.annotate,
+                    PermissionEnumV2.write,
+                    PermissionEnumV2.delete,
+                ],
+            },
+        ),
+        includePatterns=["**"],
+        excludePatterns=[],
+    ),
+perm = art.permissions.create(permission)
+
+# Update permission
+permission.repositories = ["test_repository_2"]
+updated_permission = art.permissions.update(permission)
+```
+
+##### Artifatctory lower than 6.6.0
+
+```python
+
+from pyartifactory.models import Permission, Permisson_v2
 
 # Create a permission
 permission = Permission(

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install pyartifactory
 
 ### Authentication
 
-Since Artifatctory 6.6.0 there is version 2 of the REST API for permission managmant, in case you have that version or higher, you need to pass api_version=2 to the constructor when you instantiate the calss.
+Since Artifactory 6.6.0 there is version 2 of the REST API for permission management, in case you have that version or higher, you need to pass api_version=2 to the constructor when you instantiate the class.
 
 ```python
 from pyartifactory import Artifactory
@@ -270,7 +270,7 @@ permission = PermissionV2(
         ),
         includePatterns=["**"],
         excludePatterns=[],
-    ),
+    )
 perm = art.permissions.create(permission)
 
 # Update permission

--- a/README.md
+++ b/README.md
@@ -240,10 +240,11 @@ users = art.permissions.get("test_permission")
 
 Create/Update a permission:
 
-##### Artifatctory 6.6.0 or higher
+##### Artifactory 6.6.0 or higher
 ```python
 
-from pyartifactory.models import Permisson_v2
+from pyartifactory.models import PermissionV2
+from pyartifactory.models.permission import PermissionEnumV2, PrincipalsPermissionV2, RepoV2
 
 # Create a permission
 permission = PermissionV2(
@@ -252,7 +253,7 @@ permission = PermissionV2(
         repositories=["test_repository"],
         actions=PrincipalsPermissionV2(
             users={
-                ""test_user"": [
+                "test_user": [
                     PermissionEnumV2.read,
                     PermissionEnumV2.annotate,
                     PermissionEnumV2.write,
@@ -271,18 +272,19 @@ permission = PermissionV2(
         includePatterns=["**"],
         excludePatterns=[],
     )
+)
 perm = art.permissions.create(permission)
 
 # Update permission
-permission.repositories = ["test_repository_2"]
+permission.repo.repositories = ["test_repository_2"]
 updated_permission = art.permissions.update(permission)
 ```
 
-##### Artifatctory lower than 6.6.0
+##### Artifactory lower than 6.6.0
 
 ```python
 
-from pyartifactory.models import Permission, Permisson_v2
+from pyartifactory.models import Permission
 
 # Create a permission
 permission = Permission(

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -7,9 +7,10 @@ from pyartifactory.objects import (
     ArtifactorySecurity,
     ArtifactoryRepository,
     ArtifactoryArtifact,
-    ArtifactoryPermission,
     Artifactory,
     AccessTokenModel,
+    ArtifactoryPermission,
 )
+
 
 __version__ = "1.8.3"

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -7,9 +7,9 @@ from pyartifactory.objects import (
     ArtifactorySecurity,
     ArtifactoryRepository,
     ArtifactoryArtifact,
+    ArtifactoryPermission,
     Artifactory,
     AccessTokenModel,
-    ArtifactoryPermission,
 )
 
 

--- a/pyartifactory/artifactory_object.py
+++ b/pyartifactory/artifactory_object.py
@@ -16,6 +16,7 @@ class ArtifactoryObject:
             self._artifactory.auth[0],
             self._artifactory.auth[1].get_secret_value(),
         )
+        self._api_version = self._artifactory.api_version
         self._verify = self._artifactory.verify
         self._cert = self._artifactory.cert
         self.session = requests.Session()

--- a/pyartifactory/artifactory_object.py
+++ b/pyartifactory/artifactory_object.py
@@ -1,0 +1,75 @@
+"""
+Definition of artifactory base object.
+"""
+import requests
+from requests import Response
+
+from pyartifactory.models import AuthModel
+
+
+class ArtifactoryObject:
+    """Models the artifactory object."""
+
+    def __init__(self, artifactory: AuthModel) -> None:
+        self._artifactory = artifactory
+        self._auth = (
+            self._artifactory.auth[0],
+            self._artifactory.auth[1].get_secret_value(),
+        )
+        self._verify = self._artifactory.verify
+        self._cert = self._artifactory.cert
+        self.session = requests.Session()
+
+    def _get(self, route: str, **kwargs) -> Response:
+        """
+        :param route: API Route
+        :param kwargs: Additional parameters to add the request
+        :returns  An HTTP response
+        """
+        return self._generic_http_method_request("get", route, **kwargs)
+
+    def _post(self, route: str, **kwargs) -> Response:
+        """
+        :param route: API Route
+        :param kwargs: Additional parameters to add the request
+        :returns  An HTTP response
+        """
+        return self._generic_http_method_request("post", route, **kwargs)
+
+    def _put(self, route: str, **kwargs) -> Response:
+        """
+        :param route: API Route
+        :param kwargs: Additional parameters to add the request
+        :returns  An HTTP response
+        """
+        return self._generic_http_method_request("put", route, **kwargs)
+
+    def _delete(self, route: str, **kwargs) -> Response:
+        """
+        :param route: API Route
+        :param kwargs: Additional parameters to add the request
+        :returns  An HTTP response
+        """
+        return self._generic_http_method_request("delete", route, **kwargs)
+
+    def _generic_http_method_request(
+        self, method: str, route: str, raise_for_status: bool = True, **kwargs
+    ) -> Response:
+        """
+        :param method: HTTP method to use
+        :param route: API Route
+        :param kwargs: Additional parameters to add the request
+        :return: An HTTP response
+        """
+
+        http_method = getattr(self.session, method)
+        response: Response = http_method(
+            f"{self._artifactory.url}/{route}",
+            auth=self._auth,
+            **kwargs,
+            verify=self._verify,
+            cert=self._cert,
+        )
+        if raise_for_status:
+            response.raise_for_status()
+        return response

--- a/pyartifactory/models/__init__.py
+++ b/pyartifactory/models/__init__.py
@@ -23,7 +23,7 @@ from .artifact import (
     ArtifactFolderInfoResponse,
     ArtifactInfoResponse,
 )
-from .permission import Permission, SimplePermission
+from .permission import Permission, PermissionV2, SimplePermission
 
 
 AnyRepositoryResponse = Union[

--- a/pyartifactory/models/__init__.py
+++ b/pyartifactory/models/__init__.py
@@ -31,3 +31,4 @@ AnyRepositoryResponse = Union[
 ]
 
 AnyRepository = Union[LocalRepository, VirtualRepository, RemoteRepository]
+AnyPermission = Union[Permission, PermissionV2]

--- a/pyartifactory/models/auth.py
+++ b/pyartifactory/models/auth.py
@@ -14,6 +14,7 @@ class AuthModel(BaseModel):
     auth: Tuple[str, SecretStr]
     verify: bool = True
     cert: Optional[str] = None
+    api_version: Optional[int] = 1
 
 
 class ApiKeyModel(BaseModel):

--- a/pyartifactory/models/auth.py
+++ b/pyartifactory/models/auth.py
@@ -14,7 +14,7 @@ class AuthModel(BaseModel):
     auth: Tuple[str, SecretStr]
     verify: bool = True
     cert: Optional[str] = None
-    api_version: Optional[int] = 1
+    api_version: int = 1
 
 
 class ApiKeyModel(BaseModel):

--- a/pyartifactory/models/permission.py
+++ b/pyartifactory/models/permission.py
@@ -5,7 +5,7 @@ Definition of all permission models.
 from enum import Enum
 from typing import List, Dict, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SimplePermission(BaseModel):
@@ -75,7 +75,8 @@ class RepoV2(BaseModel):
     excludePatterns: List[str] = Field([""], alias="exclude-patterns")
 
     class Config:
-        # We need this to be able to use 'includePatterns' in the constructor
+        """ We need this to be able to use 'includePatterns' in the constructor """
+
         allow_population_by_field_name = True
 
 

--- a/pyartifactory/models/permission.py
+++ b/pyartifactory/models/permission.py
@@ -40,3 +40,36 @@ class Permission(BaseModel):
     excludesPattern: str = ""
     repositories: List[str]
     principals: PrincipalsPermission
+
+
+class PermissionEnumV2(str, Enum):
+    """Enumerates a permission."""
+
+    manage = "manage"
+    delete = "delete"
+    write = "write"
+    annotate = "annotate"
+    read = "read"
+
+
+class PrincipalsPermissionV2(BaseModel):
+    """Models a principals permission API vV2."""
+
+    users: Optional[Dict[str, List[PermissionEnumV2]]] = None
+    groups: Optional[Dict[str, List[PermissionEnumV2]]] = None
+
+
+class RepoV2(BaseModel):
+    """Models a repo v2 API."""
+
+    repositories: List[str]
+    actions: PrincipalsPermissionV2
+    includesPattern: str = "**"
+    excludesPattern: str = ""
+
+
+class PermissionV2(BaseModel):
+    """Models a permission v2 API."""
+
+    name: str
+    repo: RepoV2

--- a/pyartifactory/models/permission.py
+++ b/pyartifactory/models/permission.py
@@ -53,7 +53,7 @@ class PermissionEnumV2(str, Enum):
 
 
 class PrincipalsPermissionV2(BaseModel):
-    """Models a principals permission API vV2."""
+    """Models a principals permission API v2."""
 
     users: Optional[Dict[str, List[PermissionEnumV2]]] = None
     groups: Optional[Dict[str, List[PermissionEnumV2]]] = None
@@ -64,8 +64,19 @@ class RepoV2(BaseModel):
 
     repositories: List[str]
     actions: PrincipalsPermissionV2
-    includesPattern: str = "**"
-    excludesPattern: str = ""
+    # Note: the Jfrog API changed these parameters names in v2,
+    # from 'includesPattern' to 'include-patterns'. Because they are not
+    # valid Python identifiers we chose a camelCase name for the variable,
+    # and specify the alias Pydantic should look for when deserializing.
+    # Note that when serializing this model Pydantic will by default use the
+    # identifier name, *not* the alias, so you need to pass the parameter
+    # by_alias=True when exporting (like permission.json(by_alias=True))
+    includePatterns: List[str] = Field(["**"], alias="include-patterns")
+    excludePatterns: List[str] = Field([""], alias="exclude-patterns")
+
+    class Config:
+        # We need this to be able to use 'includePatterns' in the constructor
+        allow_population_by_field_name = True
 
 
 class PermissionV2(BaseModel):

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -202,7 +202,10 @@ class ArtifactoryPermission(ArtifactoryObject):
                 f"Permission {permission_name} already exists"
             )
         except PermissionNotFoundException:
-            self._put(f"api/{self._uri}/{permission_name}", json=permission.dict(by_alias=True))
+            self._put(
+                f"api/{self._uri}/{permission_name}",
+                json=permission.dict(by_alias=True),
+            )
             logger.debug("Permission %s successfully created", permission_name)
             return self.get(permission_name)
 
@@ -252,7 +255,9 @@ class ArtifactoryPermission(ArtifactoryObject):
         :return: Permission v2 or v1
         """
         permission_name = permission.name
-        self._put(f"api/{self._uri}/{permission_name}", json=permission.dict(by_alias=True))
+        self._put(
+            f"api/{self._uri}/{permission_name}", json=permission.dict(by_alias=True)
+        )
         logger.debug("Permission %s successfully updated", permission_name)
         return self.get(permission_name)
 

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -172,12 +172,12 @@ class ArtifactoryUser(ArtifactoryObject):
 class ArtifactoryPermission(ArtifactoryObject):
     """Models an artifactory permission."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        if self._artifactory.api_version == 1:
+    def __init__(self, artifactory: AuthModel) -> None:
+        super().__init__(artifactory)
+        if self._api_version == 2:
+            self._uri = "v2/security/permissions"
+        if self._api_version == 1:
             self._uri = "security/permissions"
-        if self._artifactory.api_version == 2:
-            self.uri = "v2/security/permissions"
 
     def create(
         self, permission: Union[Permission, PermissionV2]

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -1,18 +1,18 @@
 """
 Definition of all artifactory objects.
 """
-import warnings
 import json
 import logging
 import os
+import warnings
 from os.path import isdir, join
+from pathlib import Path
 from typing import List, Optional, Dict, Tuple, Union, Iterator, overload
 
-from pathlib import Path
 import requests
-from requests import Response
 from pydantic import parse_obj_as
 
+from pyartifactory.artifactory_object import ArtifactoryObject
 from pyartifactory.exception import (
     UserNotFoundException,
     UserAlreadyExistsException,
@@ -21,13 +21,12 @@ from pyartifactory.exception import (
     GroupAlreadyExistsException,
     RepositoryNotFoundException,
     ArtifactoryException,
-    PermissionAlreadyExistsException,
-    PermissionNotFoundException,
     InvalidTokenDataException,
     PropertyNotFoundException,
     ArtifactNotFoundException,
+    PermissionAlreadyExistsException,
+    PermissionNotFoundException,
 )
-
 from pyartifactory.models import (
     AuthModel,
     ApiKeyModel,
@@ -47,17 +46,17 @@ from pyartifactory.models import (
     NewUser,
     SimpleUser,
     User,
-    Permission,
-    SimplePermission,
     ArtifactPropertiesResponse,
     ArtifactStatsResponse,
     ArtifactInfoResponse,
+    Permission,
+    PermissionV2,
+    SimplePermission,
 )
 from pyartifactory.models.artifact import (
     ArtifactFileInfoResponse,
     ArtifactFolderInfoResponse,
 )
-
 from pyartifactory.utils import custom_encoder
 
 
@@ -68,83 +67,22 @@ class Artifactory:
     """Models artifactory."""
 
     def __init__(
-        self, url: str, auth: Tuple[str, str], verify: bool = True, cert: str = None,
-    ):
-        self.artifactory = AuthModel(url=url, auth=auth, verify=verify, cert=cert)
+        self,
+        url: str,
+        auth: Tuple[str, str],
+        verify: bool = True,
+        cert: str = None,
+        api_version: int = 1,
+    ):  # pylint: disable=too-many-arguments
+        self.artifactory = AuthModel(
+            url=url, auth=auth, verify=verify, cert=cert, api_version=api_version
+        )
         self.users = ArtifactoryUser(self.artifactory)
         self.groups = ArtifactoryGroup(self.artifactory)
         self.security = ArtifactorySecurity(self.artifactory)
         self.repositories = ArtifactoryRepository(self.artifactory)
         self.artifacts = ArtifactoryArtifact(self.artifactory)
         self.permissions = ArtifactoryPermission(self.artifactory)
-
-
-class ArtifactoryObject:
-    """Models the artifactory object."""
-
-    def __init__(self, artifactory: AuthModel) -> None:
-        self._artifactory = artifactory
-        self._auth = (
-            self._artifactory.auth[0],
-            self._artifactory.auth[1].get_secret_value(),
-        )
-        self._verify = self._artifactory.verify
-        self._cert = self._artifactory.cert
-        self.session = requests.Session()
-
-    def _get(self, route: str, **kwargs) -> Response:
-        """
-        :param route: API Route
-        :param kwargs: Additional parameters to add the request
-        :returns  An HTTP response
-        """
-        return self._generic_http_method_request("get", route, **kwargs)
-
-    def _post(self, route: str, **kwargs) -> Response:
-        """
-        :param route: API Route
-        :param kwargs: Additional parameters to add the request
-        :returns  An HTTP response
-        """
-        return self._generic_http_method_request("post", route, **kwargs)
-
-    def _put(self, route: str, **kwargs) -> Response:
-        """
-        :param route: API Route
-        :param kwargs: Additional parameters to add the request
-        :returns  An HTTP response
-        """
-        return self._generic_http_method_request("put", route, **kwargs)
-
-    def _delete(self, route: str, **kwargs) -> Response:
-        """
-        :param route: API Route
-        :param kwargs: Additional parameters to add the request
-        :returns  An HTTP response
-        """
-        return self._generic_http_method_request("delete", route, **kwargs)
-
-    def _generic_http_method_request(
-        self, method: str, route: str, raise_for_status: bool = True, **kwargs
-    ) -> Response:
-        """
-        :param method: HTTP method to use
-        :param route: API Route
-        :param kwargs: Additional parameters to add the request
-        :return: An HTTP response
-        """
-
-        http_method = getattr(self.session, method)
-        response: Response = http_method(
-            f"{self._artifactory.url}/{route}",
-            auth=self._auth,
-            **kwargs,
-            verify=self._verify,
-            cert=self._cert,
-        )
-        if raise_for_status:
-            response.raise_for_status()
-        return response
 
 
 class ArtifactoryUser(ArtifactoryObject):
@@ -231,6 +169,91 @@ class ArtifactoryUser(ArtifactoryObject):
         logger.debug("User % successfully unlocked", name)
 
 
+class ArtifactoryPermission(ArtifactoryObject):
+    """Models an artifactory permission."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if self._artifactory.api_version == 1:
+            self._uri = "security/permissions"
+        if self._artifactory.api_version == 2:
+            self.uri = "v2/security/permissions"
+
+    def create(
+        self, permission: Union[Permission, PermissionV2]
+    ) -> Union[Permission, PermissionV2]:
+        """
+        Creates a permission
+        :param permission: Permission v2 or v1 object
+        :return: Permission v2 or v1
+        """
+        permission_name = permission.name
+        try:
+            self.get(permission_name)
+            logger.debug("Permission %s already exists", permission_name)
+            raise PermissionAlreadyExistsException(
+                f"Permission {permission_name} already exists"
+            )
+        except PermissionNotFoundException:
+            self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
+            logger.debug("Permission %s successfully created", permission_name)
+            return self.get(permission_name)
+
+    def get(self, permission_name: str) -> Union[Permission, PermissionV2]:
+        """
+        Read permission from artifactory. Fill object if exist
+        :param permission_name: Name of the permission to retrieve
+        :return: Permission
+        """
+        try:
+            response = self._get(f"api/{self._uri}/{permission_name}")
+            logger.debug("Permission %s found", permission_name)
+            return (
+                Permission(**response.json())
+                if self._artifactory.api_version == 1
+                else PermissionV2(**response.json())
+            )
+        except requests.exceptions.HTTPError as error:
+            if error.response.status_code == 404 or error.response.status_code == 400:
+                logger.error("Permission %s does not exist", permission_name)
+                raise PermissionNotFoundException(
+                    f"Permission {permission_name} does not exist"
+                )
+            raise ArtifactoryException from error
+
+    def list(self) -> List[SimplePermission]:
+        """
+        Lists all the permissions
+        :return: A list of permissions
+        """
+        response = self._get(f"api/{self._uri}")
+        logger.debug("List all permissions successful")
+        return [SimplePermission(**permission) for permission in response.json()]
+
+    def update(
+        self, permission: Union[Permission, PermissionV2]
+    ) -> Union[Permission, PermissionV2]:
+        """
+        Updates an artifactory permission
+        :param permission: Permission v2 or v1 object
+        :return: Permission v2 or v1
+        """
+        permission_name = permission.name
+        self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
+        logger.debug("Permission %s successfully updated", permission_name)
+        return self.get(permission_name)
+
+    def delete(self, permission_name: str) -> None:
+        """
+        Removes an artifactory permission
+        :param permission_name: Name of the permission to delete
+        :return: None
+        """
+        self.get(permission_name)
+        self._delete(f"api/{self._uri}/{permission_name}")
+        logger.debug("Permission %s successfully deleted", permission_name)
+
+
 class ArtifactorySecurity(ArtifactoryObject):
     """Models artifactory security."""
 
@@ -294,9 +317,9 @@ class ArtifactorySecurity(ArtifactoryObject):
         if not any([token, token_id]):
             logger.error("Neither a token or a token id was specified")
             raise InvalidTokenDataException
-        payload: Dict[str, Optional[str]] = {"token": token} if token else {
-            "token_id": token_id
-        }
+        payload: Dict[str, Optional[str]] = (
+            {"token": token} if token else {"token_id": token_id}
+        )
         response = self._post(
             f"api/{self._uri}/token/revoke", data=payload, raise_for_status=False
         )
@@ -710,78 +733,6 @@ class ArtifactoryRepository(ArtifactoryObject):
 
         self._delete(f"api/{self._uri}/{repo_name}")
         logger.debug("Repository %s successfully deleted", repo_name)
-
-
-class ArtifactoryPermission(ArtifactoryObject):
-    """Models an artifactory permission."""
-
-    _uri = "security/permissions"
-
-    def create(self, permission: Permission) -> Permission:
-        """
-        Creates a permission
-        :param permission: Permission object
-        :return: Permission
-        """
-        permission_name = permission.name
-        try:
-            self.get(permission_name)
-            logger.debug("Permission %s already exists", permission_name)
-            raise PermissionAlreadyExistsException(
-                f"Permission {permission_name} already exists"
-            )
-        except PermissionNotFoundException:
-            self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
-            logger.debug("Permission %s successfully created", permission_name)
-            return self.get(permission_name)
-
-    def get(self, permission_name: str) -> Permission:
-        """
-        Read permission from artifactory. Fill object if exist
-        :param permission_name: Name of the permission to retrieve
-        :return: Permission
-        """
-        try:
-            response = self._get(f"api/{self._uri}/{permission_name}")
-            logger.debug("Permission %s found", permission_name)
-            return Permission(**response.json())
-        except requests.exceptions.HTTPError as error:
-            if error.response.status_code == 404 or error.response.status_code == 400:
-                logger.error("Permission %s does not exist", permission_name)
-                raise PermissionNotFoundException(
-                    f"Permission {permission_name} does not exist"
-                )
-            raise ArtifactoryException from error
-
-    def list(self) -> List[SimplePermission]:
-        """
-        Lists all the permissions
-        :return: A list of permissions
-        """
-        response = self._get(f"api/{self._uri}")
-        logger.debug("List all permissions successful")
-        return [SimplePermission(**permission) for permission in response.json()]
-
-    def update(self, permission: Permission) -> Permission:
-        """
-        Updates an artifactory permission
-        :param permission: Permission object
-        :return: Permission
-        """
-        permission_name = permission.name
-        self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
-        logger.debug("Permission %s successfully updated", permission_name)
-        return self.get(permission_name)
-
-    def delete(self, permission_name: str) -> None:
-        """
-        Removes an artifactory permission
-        :param permission_name: Name of the permission to delete
-        :return: None
-        """
-        self.get(permission_name)
-        self._delete(f"api/{self._uri}/{permission_name}")
-        logger.debug("Permission %s successfully deleted", permission_name)
 
 
 class ArtifactoryArtifact(ArtifactoryObject):

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -202,11 +202,11 @@ class ArtifactoryPermission(ArtifactoryObject):
                 f"Permission {permission_name} already exists"
             )
         except PermissionNotFoundException:
-            self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
+            self._put(f"api/{self._uri}/{permission_name}", json=permission.dict(by_alias=True))
             logger.debug("Permission %s successfully created", permission_name)
             return self.get(permission_name)
 
-    def get(self, permission_name: str) -> Union[Permission, PermissionV2]:
+    def get(self, permission_name: str) -> AnyPermission:
         """
         Read permission from artifactory. Fill object if exist
         :param permission_name: Name of the permission to retrieve
@@ -252,7 +252,7 @@ class ArtifactoryPermission(ArtifactoryObject):
         :return: Permission v2 or v1
         """
         permission_name = permission.name
-        self._put(f"api/{self._uri}/{permission_name}", json=permission.dict())
+        self._put(f"api/{self._uri}/{permission_name}", json=permission.dict(by_alias=True))
         logger.debug("Permission %s successfully updated", permission_name)
         return self.get(permission_name)
 

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -52,6 +52,7 @@ from pyartifactory.models import (
     Permission,
     PermissionV2,
     SimplePermission,
+    AnyPermission,
 )
 from pyartifactory.models.artifact import (
     ArtifactFileInfoResponse,
@@ -73,7 +74,7 @@ class Artifactory:
         verify: bool = True,
         cert: str = None,
         api_version: int = 1,
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.artifactory = AuthModel(
             url=url, auth=auth, verify=verify, cert=cert, api_version=api_version
         )
@@ -179,9 +180,15 @@ class ArtifactoryPermission(ArtifactoryObject):
         if self._api_version == 1:
             self._uri = "security/permissions"
 
-    def create(
-        self, permission: Union[Permission, PermissionV2]
-    ) -> Union[Permission, PermissionV2]:
+    @overload
+    def create(self, permission: Permission,) -> Permission:
+        ...
+
+    @overload
+    def create(self, permission: PermissionV2,) -> PermissionV2:
+        ...
+
+    def create(self, permission: AnyPermission) -> AnyPermission:
         """
         Creates a permission
         :param permission: Permission v2 or v1 object
@@ -230,9 +237,15 @@ class ArtifactoryPermission(ArtifactoryObject):
         logger.debug("List all permissions successful")
         return [SimplePermission(**permission) for permission in response.json()]
 
-    def update(
-        self, permission: Union[Permission, PermissionV2]
-    ) -> Union[Permission, PermissionV2]:
+    @overload
+    def update(self, permission: Permission) -> Permission:
+        ...
+
+    @overload
+    def update(self, permission: PermissionV2) -> PermissionV2:
+        ...
+
+    def update(self, permission: AnyPermission) -> AnyPermission:
         """
         Updates an artifactory permission
         :param permission: Permission v2 or v1 object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ tests
 
 [tool.pylint.messages_control]
 disable = """
-bad-continuation,line-too-long,too-few-public-methods,import-error,too-many-instance-attributes
+bad-continuation,line-too-long,too-few-public-methods,import-error,too-many-instance-attributes, too-many-arguments, raise-missing-from
 """
 
 [tool.pylint.basic]

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -7,11 +7,13 @@ from pyartifactory.exception import (
     PermissionAlreadyExistsException,
 )
 from pyartifactory.models.auth import AuthModel
-from pyartifactory.models.permission import Permission, SimplePermission
+from pyartifactory.models.permission import Permission, SimplePermission, PermissionV2
+
 
 URL = "http://localhost:8080/artifactory"
 AUTH = ("user", "password_or_apiKey")
-
+API_URI = "api/security/permissions"
+API_URI_V2 = "api/v2/security/permissions"
 SIMPLE_PERMISSION = SimplePermission(name="test_permission", uri="someuri")
 PERMISSION = Permission(
     **{
@@ -23,127 +25,172 @@ PERMISSION = Permission(
         },
     }
 )
+PERMISSIONV2 = PermissionV2(
+    **{
+        "name": "test_permission",
+        "repo": {
+            "repositories": ["test_repository"],
+            "actions": {
+                "users": {"test_user": ["read", "annotate", "write", "delete",]},
+                "groups": {"developers": ["read", "annotate", "write", "delete",],},
+            },
+        },
+        "includePatterns": ["**"],
+        "excludePatterns": [],
+    }
+)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_create_permission_fail_if_group_already_exists(mocker):
+def test_create_permission_fail_if_group_already_exists(
+    mocker, api_version, permission, api_uri
+):
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
     with pytest.raises(PermissionAlreadyExistsException):
-        artifactory_permission.create(PERMISSION)
-    artifactory_permission.get.assert_called_once_with(PERMISSION.name)
+        artifactory_permission.create(permission)
+    artifactory_permission.get.assert_called_once_with(permission.name)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_create_permission_success(mocker):
-    responses.add(
-        responses.GET, f"{URL}/api/security/permissions/{PERMISSION.name}", status=404
-    )
+def test_create_permission_success(mocker, api_version, permission, api_uri):
+    responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
     responses.add(
         responses.PUT,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=201,
     )
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
-    permission = artifactory_permission.create(PERMISSION)
-    artifactory_permission.get.assert_called_with(PERMISSION.name)
-    assert permission == PERMISSION.dict()
+    permission = artifactory_permission.create(permission)
+    artifactory_permission.get.assert_called_with(permission.name)
+    assert permission == permission.dict()
 
     assert artifactory_permission.get.call_count == 2
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_get_permission_error_not_found():
-    responses.add(
-        responses.GET, f"{URL}/api/security/permissions/{PERMISSION.name}", status=404
-    )
+def test_get_permission_error_not_found(mocker, api_version, permission, api_uri):
+    responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     with pytest.raises(PermissionNotFoundException):
-        artifactory_permission.get(PERMISSION.name)
+        artifactory_permission.get(permission.name)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_get_permission_success(mocker):
+def test_get_permission_success(mocker, api_version, permission, api_uri):
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
-    permission = artifactory_permission.get(PERMISSION.name)
-    artifactory_permission.get.assert_called_with(PERMISSION.name)
+    permission = artifactory_permission.get(permission.name)
+    artifactory_permission.get.assert_called_with(permission.name)
 
-    assert permission == PERMISSION.dict()
+    assert permission == permission.dict()
 
 
+@pytest.mark.parametrize("api_version,api_uri", [(1, API_URI), (2, API_URI_V2)])
 @responses.activate
-def test_list_group_success(mocker):
+def test_list_group_success(mocker, api_version, api_uri):
     responses.add(
-        responses.GET,
-        f"{URL}/api/security/permissions",
-        json=[SIMPLE_PERMISSION.dict()],
-        status=200,
+        responses.GET, f"{URL}/{api_uri}", json=[SIMPLE_PERMISSION.dict()], status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "list")
     permission_list = artifactory_permission.list()
     artifactory_permission.list.assert_called_once()
-
     assert permission_list == [SIMPLE_PERMISSION.dict()]
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_delete_permission_fail_if_group_not_found(mocker):
-    responses.add(
-        responses.GET, f"{URL}/api/security/permissions/{PERMISSION.name}", status=404
-    )
+def test_delete_permission_fail_if_group_not_found(
+    mocker, api_version, permission, api_uri
+):
+    responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
 
     with pytest.raises(PermissionNotFoundException):
-        artifactory_permission.delete(PERMISSION.name)
+        artifactory_permission.delete(permission.name)
 
-    artifactory_permission.get.assert_called_once_with(PERMISSION.name)
+    artifactory_permission.get.assert_called_once_with(permission.name)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_delete_group_success(mocker):
+def test_delete_group_success(mocker, api_version, permission, api_uri):
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
     responses.add(
-        responses.DELETE,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        status=204,
+        responses.DELETE, f"{URL}/{api_uri}/{permission.name}", status=204,
     )
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
-    artifactory_permission.delete(PERMISSION.name)
+    artifactory_permission.delete(permission.name)
 
-    artifactory_permission.get.assert_called_once_with(PERMISSION.name)
+    artifactory_permission.get.assert_called_once_with(permission.name)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -35,8 +35,8 @@ PERMISSIONV2 = PermissionV2(
                 "groups": {"developers": ["read", "annotate", "write", "delete",],},
             },
         },
-        "includePatterns": ["**"],
-        "excludePatterns": [],
+        "include-patterns": ["**"],
+        "exclude-patterns": [],
     }
 )
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -101,7 +101,7 @@ def test_create_permission_success(mocker, api_version, permission, api_uri):
     [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
 )
 @responses.activate
-def test_get_permission_error_not_found(mocker, api_version, permission, api_uri):
+def test_get_permission_error_not_found(api_version, permission, api_uri):
     responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
 
     artifactory_permission = ArtifactoryPermission(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -89,9 +89,9 @@ def test_create_permission_success(mocker, api_version, permission, api_uri):
         AuthModel(url=URL, auth=AUTH, api_version=api_version)
     )
     mocker.spy(artifactory_permission, "get")
-    permission = artifactory_permission.create(permission)
+    mocked_permission = artifactory_permission.create(permission)
     artifactory_permission.get.assert_called_with(permission.name)
-    assert permission == permission.dict()
+    assert mocked_permission == permission.dict()
 
     assert artifactory_permission.get.call_count == 2
 
@@ -128,10 +128,10 @@ def test_get_permission_success(mocker, api_version, permission, api_uri):
         AuthModel(url=URL, auth=AUTH, api_version=api_version)
     )
     mocker.spy(artifactory_permission, "get")
-    permission = artifactory_permission.get(permission.name)
+    mocked_permission = artifactory_permission.get(permission.name)
     artifactory_permission.get.assert_called_with(permission.name)
 
-    assert permission == permission.dict()
+    assert mocked_permission == permission.dict()
 
 
 @pytest.mark.parametrize("api_version,api_uri", [(1, API_URI), (2, API_URI_V2)])


### PR DESCRIPTION
The V2 REST APIs apply for Artifactory version 6.6.0
and above, the user can pass the version explicitly.

Currently this only affects Permissions.

## Description
The permission scheme has changed in new version of artifactory, I had to find a way to behave based on API version supported by the server. 
Trying dynamic check of the server version I ended up in 5-6 server calls for each class that was called in class Artifactory.__init__
So At the end I opted for adding an argument that can be send to the constructor at the time the class is instantiated 

https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API+V2

I turned of the complexity fail on number of arguments, as all the ways around it would add more complexity. but I'm open to suggestions. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Against a live deployment
- [x] Unit tests updated and checked


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
