### PR TITLE
feat: add build and releaseBundle to PermissionV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Security](#security)
     + [Repository](#repository)
     + [Permission](#permission)
-      - [Artifactory 6.6.0 or higher](#artifactory-660-or-higher)
       - [Artifactory lower than 6.6.0](#artifactory-lower-than-660)
+      - [Artifactory 6.6.0 or higher](#artifactory-660-or-higher)
   * [Artifacts](#artifacts)
     + [Get the information about a file or folder](#get-the-information-about-a-file-or-folder)
     + [Deploy an artifact](#deploy-an-artifact)
@@ -240,11 +240,38 @@ users = art.permissions.get("test_permission")
 
 Create/Update a permission:
 
-##### Artifactory 6.6.0 or higher
+##### Artifactory lower than 6.6.0
+
 ```python
 
+from pyartifactory.models import Permission
+
+# Create a permission
+permission = Permission(
+    **{
+        "name": "test_permission",
+        "repositories": ["test_repository"],
+        "principals": {
+            "users": {"test_user": ["r", "w", "n", "d"]},
+            "groups": {"developers": ["r"]},
+        },
+    }
+)
+perm = art.permissions.create(permission)
+
+# Update permission
+permission.repositories = ["test_repository_2"]
+updated_permission = art.permissions.update(permission)
+```
+
+##### Artifactory 6.6.0 or higher
+```python
+from pyartifactory import Artifactory
 from pyartifactory.models import PermissionV2
 from pyartifactory.models.permission import PermissionEnumV2, PrincipalsPermissionV2, RepoV2, BuildV2, ReleaseBundleV2
+
+# To use PermissionV2, make sure to set api_version=2
+art = Artifactory(url="ARTIFACTORY_URL", auth=('USERNAME','PASSWORD_OR_API_KEY'), api_version=2)
 
 # Create a permission
 permission = PermissionV2(
@@ -314,30 +341,6 @@ perm = art.permissions.create(permission)
 
 # Update permission
 permission.repo.repositories = ["test_repository_2"]
-updated_permission = art.permissions.update(permission)
-```
-
-##### Artifactory lower than 6.6.0
-
-```python
-
-from pyartifactory.models import Permission
-
-# Create a permission
-permission = Permission(
-    **{
-        "name": "test_permission",
-        "repositories": ["test_repository"],
-        "principals": {
-            "users": {"test_user": ["r", "w", "n", "d"]},
-            "groups": {"developers": ["r"]},
-        },
-    }
-)
-perm = art.permissions.create(permission)
-
-# Update permission
-permission.repositories = ["test_repository_2"]
 updated_permission = art.permissions.update(permission)
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Create/Update a permission:
 ```python
 
 from pyartifactory.models import PermissionV2
-from pyartifactory.models.permission import PermissionEnumV2, PrincipalsPermissionV2, RepoV2
+from pyartifactory.models.permission import PermissionEnumV2, PrincipalsPermissionV2, RepoV2, BuildV2, ReleaseBundleV2
 
 # Create a permission
 permission = PermissionV2(
@@ -271,7 +271,44 @@ permission = PermissionV2(
         ),
         includePatterns=["**"],
         excludePatterns=[],
-    )
+    ),
+    build=BuildV2(
+          actions=PrincipalsPermissionV2(
+              users={
+                  "test_user": [
+                      PermissionEnumV2.read,
+                      PermissionEnumV2.write,
+                  ]
+              },
+              groups={
+                  "developers": [
+                      PermissionEnumV2.read,
+                      PermissionEnumV2.write,
+                  ],
+              },
+          ),
+          includePatterns=[""],
+          excludePatterns=[""],
+      ),
+    releaseBundle=ReleaseBundleV2(
+          repositories=["release-bundles"],
+          actions=PrincipalsPermissionV2(
+              users={
+                  "test_user": [
+                      PermissionEnumV2.read,
+                  ]
+              },
+              groups={
+                  "developers": [
+                      PermissionEnumV2.read,
+                  ],
+              },
+          ),
+          includePatterns=[""],
+          excludePatterns=[""],
+      )
+  # You don't have to set all the objects repo, build and releaseBundle
+  # If you only need repo for example, you can set only the repo object
 )
 perm = art.permissions.create(permission)
 

--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -13,4 +13,4 @@ from pyartifactory.objects import (
 )
 
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"

--- a/pyartifactory/models/permission.py
+++ b/pyartifactory/models/permission.py
@@ -50,6 +50,8 @@ class PermissionEnumV2(str, Enum):
     write = "write"
     annotate = "annotate"
     read = "read"
+    distribute = "distribute"
+    managedXrayMeta = "managedXrayMeta"
 
 
 class PrincipalsPermissionV2(BaseModel):
@@ -59,8 +61,8 @@ class PrincipalsPermissionV2(BaseModel):
     groups: Optional[Dict[str, List[PermissionEnumV2]]] = None
 
 
-class RepoV2(BaseModel):
-    """Models a repo v2 API."""
+class BasePermissionV2(BaseModel):
+    """Models the base of a permission v2 API."""
 
     repositories: List[str]
     actions: PrincipalsPermissionV2
@@ -80,8 +82,27 @@ class RepoV2(BaseModel):
         allow_population_by_field_name = True
 
 
+class RepoV2(BasePermissionV2):
+    """Models a repo v2 API."""
+
+
+class BuildV2(BasePermissionV2):
+    """Models a build v2 API."""
+
+    includePatterns: List[str] = Field([""], alias="include-patterns")
+    repositories: List[str] = ["artifactory-build-info"]
+
+
+class ReleaseBundleV2(BasePermissionV2):
+    """Models a releaseBundle v2 API."""
+
+    excludePatterns: List[str] = Field([], alias="exclude-patterns")
+
+
 class PermissionV2(BaseModel):
     """Models a permission v2 API."""
 
     name: str
-    repo: RepoV2
+    repo: Optional[RepoV2] = None
+    build: Optional[BuildV2] = None
+    releaseBundle: Optional[ReleaseBundleV2] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyArtifactory"
-version = "1.9.0"
+version = "1.9.1"
 description = "Typed interactions with the Jfrog Artifactory REST API"
 authors = ["Ananias CARVALHO <carvalhoananias@hotmail.com>", "Thomas GAUDIN <thomas.gaudin@centraliens-lille.org>"]
 license = "MIT"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -29,14 +29,35 @@ PERMISSIONV2 = PermissionV2(
     **{
         "name": "test_permission",
         "repo": {
+            "include-patterns": ["**"],
+            "exclude-patterns": [],
             "repositories": ["test_repository"],
             "actions": {
-                "users": {"test_user": ["read", "annotate", "write", "delete",]},
-                "groups": {"developers": ["read", "annotate", "write", "delete",],},
+                "users": {"test_user": ["read", "annotate", "write", "delete"]},
+                "groups": {"developers": ["read", "annotate", "write", "delete"]},
             },
         },
-        "include-patterns": ["**"],
-        "exclude-patterns": [],
+        "build": {
+            "include-patterns": [""],
+            "exclude-patterns": [""],
+            "repositories": ["artifactory-build-info"],
+            "actions": {
+                "users": {"bob": ["read", "manage"], "alice": ["write"]},
+                "groups": {
+                    "dev-leads": ["manage", "read", "write", "annotate", "delete"],
+                    "readers": ["read"],
+                },
+            },
+        },
+        "releaseBundle": {
+            "include-patterns": ["**"],
+            "exclude-patterns": [],
+            "repositories": ["release-bundles"],
+            "actions": {
+                "users": {"user_name": ["read", "write"]},
+                "groups": {"group_name": ["read", "write"]},
+            },
+        },
     }
 )
 


### PR DESCRIPTION
## Description

The PermissionV2 feature is not complete. Indeed, the objects build and releaseBundle are missing and if you update an existing permission which has both "repo" and "build" but don't set one or the other, the corresponding sub-permission is removed.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
