### PR TITLE
Support for setting artifact properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,18 @@ artifact_properties = art.artifacts.properties("<ARTIFACT_PATH_IN_ARTIFACTORY>",
 artifact_properties.properties["prop1"]  # ["value1", "value1-bis"]
 ```
 
+#### Set artifact properties
+```python
+artifact_properties = art.artifacts.set_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", {"prop1": "value", "prop2": "value"})  # recursive mode is enabled by default
+artifact_properties = art.artifacts.set_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", {"prop1": "value", "prop2": "value"}, False) # disable recursive mode
+```
+
+#### Update artifact properties
+```python
+artifact_properties = art.artifacts.update_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", {"prop1": "value", "prop2": "value"})  # recursive mode is enabled by default
+artifact_properties = art.artifacts.update_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", {"prop1": "value", "prop2": "value"}, False) # disable recursive mode
+```
+
 #### Retrieve artifact stats
 ```python
 artifact_stats = art.artifacts.stats("<ARTIFACT_PATH_IN_ARTIFACTORY>")

--- a/pyartifactory/artifactory_object.py
+++ b/pyartifactory/artifactory_object.py
@@ -53,6 +53,14 @@ class ArtifactoryObject:
         """
         return self._generic_http_method_request("delete", route, **kwargs)
 
+    def _patch(self, route: str, **kwargs) -> Response:
+        """
+        :param route: API Route
+        :param kwargs: Additional parameters to add the request
+        :returns  An HTTP response
+        """
+        return self._generic_http_method_request("patch", route, **kwargs)
+
     def _generic_http_method_request(
         self, method: str, route: str, raise_for_status: bool = True, **kwargs
     ) -> Response:

--- a/pyartifactory/exception.py
+++ b/pyartifactory/exception.py
@@ -43,6 +43,10 @@ class ArtifactNotFoundException(ArtifactoryException):
     """An artifact was not found"""
 
 
+class BadPropertiesException(ArtifactoryException):
+    """Property value includes invalid characters"""
+
+
 class PropertyNotFoundException(ArtifactoryException):
     """All requested properties were not found"""
 

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -913,6 +913,38 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 )
             raise ArtifactoryException from error
 
+    def set_properties(
+        self, artifact_path: str, properties: Dict[str, str], recursive: bool = True
+    ) -> None:
+        """
+        :param artifact_path: Path to file or folder in Artifactory
+        :param properties: List of properties to update
+        :param recursive: If set to true, properties will be applied recursively to subfolders and files
+        :return: None
+        """
+        if properties is None:
+            properties = {}
+        artifact_path = artifact_path.lstrip("/")
+        properties_param_str = ""
+        for prop in properties:
+            properties_param_str += f"{prop}={properties[prop]};"
+        try:
+            self._put(
+                f"api/storage/{artifact_path}",
+                params={
+                    "recursive": int(recursive),
+                    "properties": properties_param_str,
+                },
+            )
+            logger.debug("Artifact Properties successfully set")
+        except requests.exceptions.HTTPError as error:
+            if error.response.status_code == 404:
+                logger.error("Artifact %s does not exist", artifact_path)
+                raise ArtifactNotFoundException(
+                    f"Artifact {artifact_path} does not exist"
+                )
+            raise ArtifactoryException from error
+
     def update_properties(
         self, artifact_path: str, properties: Dict[str, str], recursive: bool = True
     ) -> None:

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -913,6 +913,35 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 )
             raise ArtifactoryException from error
 
+    def update_properties(
+        self, artifact_path: str, properties: Dict[str, str], recursive: bool = True
+    ) -> None:
+        """
+        :param artifact_path: Path to file or folder in Artifactory
+        :param properties: List of properties to update
+        :param recursive: If set to true, properties will be applied recursively to subfolders and files
+        :return: None
+        """
+        if properties is None:
+            properties = {}
+        artifact_path = artifact_path.lstrip("/")
+        payload = json.dumps({"props": properties})
+        try:
+            self._patch(
+                f"api/metadata/{artifact_path}",
+                params={"recursive": int(recursive)},
+                headers={"Content-Type": "application/json"},
+                data=payload,
+            )
+            logger.debug("Artifact Properties successfully updated")
+        except requests.exceptions.HTTPError as error:
+            if error.response.status_code == 400:
+                logger.error("Artifact %s does not exist", artifact_path)
+                raise ArtifactNotFoundException(
+                    f"Artifact {artifact_path} does not exist"
+                )
+            raise ArtifactoryException from error
+
     def stats(self, artifact_path: str) -> ArtifactStatsResponse:
         """
         :param artifact_path: Path to file in Artifactory

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -3,8 +3,12 @@ import responses
 import urllib.parse
 
 from pyartifactory import ArtifactoryArtifact
-from pyartifactory.exception import PropertyNotFoundException, ArtifactNotFoundException, BadPropertiesException,\
-    ArtifactoryException
+from pyartifactory.exception import (
+    PropertyNotFoundException,
+    ArtifactNotFoundException,
+    BadPropertiesException,
+    ArtifactoryException,
+)
 from pyartifactory.models import (
     ArtifactPropertiesResponse,
     ArtifactStatsResponse,
@@ -362,10 +366,12 @@ def test_set_property_success():
         responses.GET,
         f"{URL}/api/storage/{ARTIFACT_PATH}?properties=",
         json=ARTIFACT_MULTIPLE_PROPERTIES.dict(),
-        status=200
+        status=200,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    set_properties_response = artifactory.set_properties(ARTIFACT_PATH, ARTIFACT_MULTIPLE_PROPERTIES.properties)
+    set_properties_response = artifactory.set_properties(
+        ARTIFACT_PATH, ARTIFACT_MULTIPLE_PROPERTIES.properties
+    )
     assert set_properties_response == ARTIFACT_MULTIPLE_PROPERTIES
 
 
@@ -382,12 +388,17 @@ def test_set_property_fail_artifact_not_found():
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     with pytest.raises(ArtifactNotFoundException):
-        artifactory.set_properties(NX_ARTIFACT_PATH, ARTIFACT_ONE_PROPERTY.properties)
+        set_property_response = artifactory.set_properties(
+            NX_ARTIFACT_PATH, ARTIFACT_ONE_PROPERTY.properties
+        )
+        assert set_property_response is None
 
 
 @responses.activate
 def test_set_property_fail_bad_value():
-    properties_param_str = urllib.parse.quote_plus(f"{BAD_PROPERTY_NAME}={BAD_PROPERTY_VALUE};")
+    properties_param_str = urllib.parse.quote_plus(
+        f"{BAD_PROPERTY_NAME}={BAD_PROPERTY_VALUE};"
+    )
     responses.add(
         responses.PUT,
         f"{URL}/api/storage/{ARTIFACT_PATH}?recursive=1&properties={properties_param_str}",
@@ -395,7 +406,10 @@ def test_set_property_fail_bad_value():
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     with pytest.raises(BadPropertiesException):
-        artifactory.set_properties(ARTIFACT_PATH, {BAD_PROPERTY_NAME: [BAD_PROPERTY_VALUE]})
+        set_property_response = artifactory.set_properties(
+            ARTIFACT_PATH, {BAD_PROPERTY_NAME: [BAD_PROPERTY_VALUE]}
+        )
+        assert set_property_response is None
 
 
 @responses.activate
@@ -404,18 +418,22 @@ def test_update_property_success():
         responses.PATCH,
         f"{URL}/api/metadata/{ARTIFACT_PATH}?recursive=1",
         match=[
-            responses.matchers.json_params_matcher({"props": ARTIFACT_MULTIPLE_PROPERTIES.properties})
+            responses.matchers.json_params_matcher(
+                {"props": ARTIFACT_MULTIPLE_PROPERTIES.properties}
+            )
         ],
-        status=200
+        status=200,
     )
     responses.add(
         responses.GET,
         f"{URL}/api/storage/{ARTIFACT_PATH}?properties=",
         json=ARTIFACT_MULTIPLE_PROPERTIES.dict(),
-        status=200
+        status=200,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    update_properties_response = artifactory.update_properties(ARTIFACT_PATH, ARTIFACT_MULTIPLE_PROPERTIES.properties)
+    update_properties_response = artifactory.update_properties(
+        ARTIFACT_PATH, ARTIFACT_MULTIPLE_PROPERTIES.properties
+    )
     assert update_properties_response == ARTIFACT_MULTIPLE_PROPERTIES
 
 
@@ -425,13 +443,18 @@ def test_update_property_fail_artifact_not_found():
         responses.PATCH,
         f"{URL}/api/metadata/{NX_ARTIFACT_PATH}?recursive=1",
         match=[
-            responses.matchers.json_params_matcher({"props": ARTIFACT_ONE_PROPERTY.properties})
+            responses.matchers.json_params_matcher(
+                {"props": ARTIFACT_ONE_PROPERTY.properties}
+            )
         ],
         status=400,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     with pytest.raises(ArtifactoryException):
-        artifactory.update_properties(NX_ARTIFACT_PATH, ARTIFACT_ONE_PROPERTY.properties)
+        update_properties_response = artifactory.update_properties(
+            NX_ARTIFACT_PATH, ARTIFACT_ONE_PROPERTY.properties
+        )
+        assert update_properties_response is None
 
 
 @responses.activate
@@ -440,10 +463,15 @@ def test_update_property_fail_bad_value():
         responses.PATCH,
         f"{URL}/api/metadata/{ARTIFACT_PATH}?recursive=1",
         match=[
-            responses.matchers.json_params_matcher({"props": {BAD_PROPERTY_NAME: [BAD_PROPERTY_VALUE]}})
+            responses.matchers.json_params_matcher(
+                {"props": {BAD_PROPERTY_NAME: [BAD_PROPERTY_VALUE]}}
+            )
         ],
         status=400,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     with pytest.raises(ArtifactoryException):
-        artifactory.update_properties(ARTIFACT_PATH, {BAD_PROPERTY_NAME: [BAD_PROPERTY_VALUE]})
+        update_properties_response = artifactory.update_properties(
+            ARTIFACT_PATH, {BAD_PROPERTY_NAME: [BAD_PROPERTY_VALUE]}
+        )
+        assert update_properties_response is None


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes #91 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has it been tested ?

Tested manually with Artifactory 7:

- [x] set/update a single property on an existing artifact
- [x] set/update multiple properties on an existing artifact
- [x] set/update an empty property list on an existing artifact
- [x] set/update a single property on an non-existing artifact (ArtifactNotFoundException is thrown)
- [x] set/update a single property on an existing artifact in non-recursive mode (Note: There is a known issue: RTFACT-25982)

As the API calls used do not return any data other than the HTTP status code, I'm not sure what's the proper approach to automated testing. 

## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
