### PR TITLE
update RemoteRepository attribute

### DIFF
--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -269,6 +269,7 @@ class RemoteRepository(BaseRepositoryModel):
     downloadRedirect: bool = False
     contentSynchronisation: ContentSynchronisation = ContentSynchronisation()
     nuget: Nuget = Nuget()
+    xrayIndex: bool = False
 
 
 class RemoteRepositoryResponse(RemoteRepository):


### PR DESCRIPTION
Add xrayIndex attribute to Class RemoteRepository to enable the xrayIndex option when creating a remote repository.

## Description

Added a default attribute to Class RemoteRepository to fix the following issue:
Fixes #96 

## Type of change

Please delete options that are not relevant.

- [ ]Bug fix (non-breaking change which fixes an issue)


## How has it been tested ?
env: windows 10, python 3.7

Tested creating a remote repository using following codes:
```pyhton
remote_repo = RemoteRepository(key="test-1", url="https://registry.npmjs.org", packageType="npm", xrayIndex=True)
new_remote_repo = art.repositories.create_repo(remote_repo)
```
Checked in the jfrog GUI and the newly created remote repo "test-1" has enabled "Enable Indexing In Xray".

## Checklist:

- [√] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [√] All commits have a correct title
- [ ] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
