### PR TITLE
Email should be optional as admin may have none

### DIFF
--- a/pyartifactory/models/user.py
+++ b/pyartifactory/models/user.py
@@ -45,7 +45,8 @@ class User(BaseUserModel):
 class UserResponse(BaseUserModel):
     """Models a user response."""
 
-    email: EmailStr
+    # Email should be optional as admin may have none
+    email: Optional[EmailStr] = None
     lastLoggedIn: Optional[datetime] = None
     realm: Optional[str] = None
     offlineMode: bool = False


### PR DESCRIPTION
Even if the email field is somewhat required, is some events such as fetching the admin user, the UserResponse class fails to parse artifactory's answer.