### PR TITLE
Remove Nuget repo model and flatten RemoteRepository model

### DIFF
--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -112,14 +112,6 @@ class ContentSynchronisation(BaseModel):
     source: Source = Source()
 
 
-class Nuget(BaseModel):
-    """Models a nuget feed."""
-
-    feedContextPath: str = "api/v2"
-    downloadContextPath: str = "api/v2/package"
-    v3FeedUrl: str = "https://api.nuget.org/v3/index.json"
-
-
 class SimpleRepository(BaseModel):
     """Models a simple repository."""
 
@@ -269,7 +261,9 @@ class RemoteRepository(BaseRepositoryModel):
     externalDependenciesPatterns: List[str] = ["**/*microsoft*/**", "**/*github*/**"]
     downloadRedirect: bool = False
     contentSynchronisation: ContentSynchronisation = ContentSynchronisation()
-    nuget: Nuget = Nuget()
+    feedContextPath: str = "api/v2"
+    downloadContextPath: str = "api/v2/package"
+    v3FeedUrl: str = "https://api.nuget.org/v3/index.json"
     xrayIndex: bool = False
 
 


### PR DESCRIPTION
## Description

This change flattens the `RemoteRepository` model and removes the `Nuget` repository model. The attributes of the `Nuget` repository have been moved to the `RemoteRepository` model. When JSON encoded, this model is in a structure that is expected by the Artifactory API when making calls to create/update a `RemoteRepository` of type `NuGet`. 

Fixes #106 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] `Pre-Commit`
- [x] `pytest --cov=pyartifactory --cov-branch`


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [ ] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
