### PR TITLE
fix: dependency issue : typing_extensions

### DIFF
--- a/pyartifactory/__init__.py
+++ b/pyartifactory/__init__.py
@@ -13,4 +13,4 @@ from pyartifactory.objects import (
 )
 
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyArtifactory"
-version = "1.10.1"
+version = "1.10.2"
 description = "Typed interactions with the Jfrog Artifactory REST API"
 authors = ["Ananias CARVALHO <carvalhoananias@hotmail.com>", "Thomas GAUDIN <thomas.gaudin@centraliens-lille.org>"]
 license = "MIT"
@@ -49,7 +49,7 @@ requests = "^2.21"
 email_validator = "^1.0"
 pydantic = "^1.4"
 typing_extensions = [
-    { version = "^3.7.4", python = "^3.6" },
+    { version = "^3.7.4", python = "~3.6" },
     { version = "^4", python = "^3.7" },
 ]
 


### PR DESCRIPTION
## Description

Fix the dependency issue when install pyartifactory on python greater then 3.7

Fixes # (119)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has it been tested ?

- Version are resolved successfully on python 3.9 & python 3.8


## Checklist:

- [ ] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [ ] All commits have a correct title
- [ ] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
