### PR TITLE
feat: allow specifying repository project key

### DIFF
--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -126,6 +126,7 @@ class BaseRepositoryModel(BaseModel):
     """Models a base repository."""
 
     key: str
+    projectKey: Optional[str] = None
     rclass: RClassEnum
     packageType: PackageTypeEnum = PackageTypeEnum.generic
     description: Optional[str] = None


### PR DESCRIPTION
## Description

Adds the projectKey param to BaseRepositoryModel to be able to create repos under a project.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
