### PR TITLE
Add cargoInternalIndex value for local-repos

### DIFF
--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -285,6 +285,7 @@ class RemoteRepository(BaseRepositoryModel):
     priorityResolution: bool = False
     disableUrlNormalization: bool = False
     xrayIndex: bool = False
+    cargoInternalIndex: bool = False
 
 
 class RemoteRepositoryResponse(RemoteRepository):

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -165,6 +165,7 @@ class LocalRepository(BaseRepositoryModel):
     primaryKeyPairRef: Optional[str] = None
     secondaryKeyPairRef: Optional[str] = None
     priorityResolution: str = "false"
+    cargoInternalIndex: bool = False
 
 
 class LocalRepositoryResponse(LocalRepository):


### PR DESCRIPTION
## Description

JFrog now supports [Sparse Indices for Cargo repositories](https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html) (see [API docs](https://www.jfrog.com/confluence/display/JFROG/Repository+Configuration+JSON)). This is done through the `"cargoInternalIndex": "bool"` value.

These are stabilising on the 9th of March, so exposing these to automations will be useful.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has it been tested ?

I have smoketested this change against our local Artifactory.

## Checklist:

- [X ] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [X] All commits have a correct title
- [x] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
