### PR TITLE
Fix test_download_artifact_success on Windows

### DIFF
--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -187,7 +187,7 @@ def test_download_artifact_success(tmp_path):
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
     artifact = artifactory.download(ARTIFACT_PATH, str(tmp_path.resolve()))
 
-    assert artifact.as_posix() == f"{tmp_path.resolve()}/{artifact_name}"
+    assert artifact.as_posix() == f"{tmp_path.as_posix()}/{artifact_name}"
     assert artifact.is_file()
 
 


### PR DESCRIPTION
## Description

test_download_artifact_success fails on Windows because `ArtifactoryArtifact.as_posix` returns forward slashes, whereas the test expects backward ones.  Use `Path.as_posix` instead of `Path.resolve` in the test case to expect forward slashes instead.

Here's the test output without this change:

```
==================================================================================== FAILURES ====================================================================================
_________________________________________________________________________ test_download_artifact_success _________________________________________________________________________

tmp_path = WindowsPath('C:/Users/mkraai/AppData/Local/Temp/1/pytest-of-mkraai/pytest-4/test_download_artifact_success0')

    @responses.activate
    def test_download_artifact_success(tmp_path):
        artifact_name = ARTIFACT_PATH.split("/")[1]
        responses.add(
            responses.GET,
            f"{URL}/api/storage/{ARTIFACT_PATH}",
            status=200,
            json=FILE_INFO_RESPONSE,
        )
        responses.add(responses.GET, f"{URL}/{ARTIFACT_PATH}", json=artifact_name, status=200)

        artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
        artifact = artifactory.download(ARTIFACT_PATH, str(tmp_path.resolve()))

>       assert artifact.as_posix() == f"{tmp_path.resolve()}/{artifact_name}"
E       AssertionError: assert 'C:/Users/mkr...ess0/file.txt' == 'C:\\Users\\m...ess0/file.txt'
E
E         - C:\Users\mkraai\AppData\Local\Temp\1\pytest-of-mkraai\pytest-4\test_download_artifact_success0/file.txt
E         ?   ^     ^      ^       ^     ^    ^ ^                ^        ^
E         + C:/Users/mkraai/AppData/Local/Temp/1/pytest-of-mkraai/pytest-4/test_download_artifact_success0/file.txt
E         ?   ^     ^      ^       ^     ^    ^ ^                ^        ^

tests\test_artifacts.py:190: AssertionError
============================================================================ short test summary info =============================================================================
FAILED tests/test_artifacts.py::test_download_artifact_success - AssertionError: assert 'C:/Users/mkr...ess0/file.txt' == 'C:\\Users\\m...ess0/file.txt'
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has it been tested ?

I tested this change by running `pytest` and verifying that there were no failures.

## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [ ] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
