### PR TITLE
Feature: Added federated repo type

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,12 @@ repo = art.repositories.get_repo("repo_name")
 
 Create/Update a repository:
 ```python
-from pyartifactory.models import LocalRepository, VirtualRepository, RemoteRepository
+from pyartifactory.models import (
+    LocalRepository,
+    VirtualRepository,
+    RemoteRepository,
+    FederatedRepository
+)
 
 # Create local repo
 local_repo = LocalRepository(key="test_local_repo")
@@ -230,6 +235,10 @@ new_virtual_repo = art.repositories.create_repo(virtual_repo)
 # Create remote repo
 remote_repo = RemoteRepository(key="test_remote_repo")
 new_remote_repo = art.repositories.create_repo(remote_repo)
+
+# Create federated repo
+remote_repo = FederatedRepository(key="test_remote_repo")
+new_federated_repo = art.repositories.create_repo(remote_repo)
 
 # Update a repository
 local_repo = art.repositories.get_repo("test_local_repo")

--- a/pyartifactory/models/__init__.py
+++ b/pyartifactory/models/__init__.py
@@ -16,6 +16,8 @@ from .auth import AccessTokenModel, ApiKeyModel, AuthModel, PasswordModel
 from .group import Group, SimpleGroup
 from .permission import Permission, PermissionV2, SimplePermission
 from .repository import (
+    FederatedRepository,
+    FederatedRepositoryResponse,
     LocalRepository,
     LocalRepositoryResponse,
     RemoteRepository,
@@ -26,9 +28,14 @@ from .repository import (
 )
 from .user import BaseUserModel, NewUser, SimpleUser, User, UserResponse
 
-AnyRepositoryResponse = Union[LocalRepositoryResponse, VirtualRepositoryResponse, RemoteRepositoryResponse]
+AnyRepositoryResponse = Union[
+    LocalRepositoryResponse,
+    VirtualRepositoryResponse,
+    RemoteRepositoryResponse,
+    FederatedRepositoryResponse,
+]
 
-AnyRepository = Union[LocalRepository, VirtualRepository, RemoteRepository]
+AnyRepository = Union[LocalRepository, VirtualRepository, RemoteRepository, FederatedRepository]
 AnyPermission = Union[Permission, PermissionV2]
 
 __all__ = [
@@ -50,6 +57,8 @@ __all__ = [
     "LocalRepositoryResponse",
     "RemoteRepository",
     "RemoteRepositoryResponse",
+    "FederatedRepository",
+    "FederatedRepositoryResponse",
     "SimpleRepository",
     "VirtualRepository",
     "VirtualRepositoryResponse",

--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -51,6 +51,7 @@ class RClassEnum(str, Enum):
     local = "local"
     virtual = "virtual"
     remote = "remote"
+    federated = "federated"
 
 
 class ChecksumPolicyType(str, Enum):
@@ -112,6 +113,18 @@ class ContentSynchronisation(BaseModel):
     statistics: Statistics = Statistics()
     properties: Properties = Properties()
     source: Source = Source()
+
+
+class FederatedMembers(BaseModel):
+    url: str = ""
+    enabled: Literal["true", "false"] = "true"
+
+
+class FederatedMembersResponse(BaseModel):
+    """Models a federated member response."""
+
+    url: str = ""
+    enabled: bool = True
 
 
 class SimpleRepository(BaseModel):
@@ -291,6 +304,66 @@ class RemoteRepositoryResponse(RemoteRepository):
 
     dockerApiVersion: str = "V2"
     debianTrivialLayout: bool = False
+    enableComposerSupport: bool = False
+    enableNuGetSupport: bool = False
+    enableGemsSupport: bool = False
+    enableNpmSupport: bool = False
+    enableBowerSupport: bool = False
+    enableCocoaPodsSupport: bool = False
+    enableConanSupport: bool = False
+    enableDebianSupport: bool = False
+    enablePypiSupport: bool = False
+    enablePuppetSupport: bool = False
+    enableDockerSupport: bool = False
+    forceNugetAuthentication: bool = False
+    enableVagrantSupport: bool = False
+    enableGitLfsSupport: bool = False
+    enableDistRepoSupport: bool = False
+
+
+class FederatedBaseRepostoryModel(BaseRepositoryModel):
+    """
+    Models a basic federated repo without members as they can't be overwritten
+    and differ in response and request
+    """
+
+    rclass: Literal[RClassEnum.federated] = RClassEnum.federated
+    checksumPolicyType: ChecksumPolicyType = ChecksumPolicyType.client_checksums
+    handleReleases: bool = True
+    handleSnapshots: bool = True
+    maxUniqueSnapshots: int = 0
+    maxUniqueTags: int = 0
+    debianTrivialLayout: bool = False
+    snapshotVersionBehavior: SnapshotVersionBehavior = SnapshotVersionBehavior.non_unique
+    suppressPomConsistencyChecks: bool = False
+    blackedOut: bool = False
+    xrayIndex: bool = False
+    propertySets: Optional[List[str]] = None
+    dockerApiVersion: str = "V2"
+    archiveBrowsingEnabled: bool = False
+    calculateYumMetadata: bool = False
+    yumRootDepth: int = 0
+    enableFileListsIndexing: bool = False
+    optionalIndexCompressionFormats: Optional[List[str]] = None
+    downloadRedirect: bool = False
+    cdnRedirect: bool = False
+    blockPushingSchema1: bool = False
+    primaryKeyPairRef: Optional[str] = None
+    secondaryKeyPairRef: Optional[str] = None
+    priorityResolution: bool = False
+    cargoInternalIndex: bool = False
+
+
+class FederatedRepository(FederatedBaseRepostoryModel):
+    """Models a federated Repository (member model differs from reponse)."""
+
+    members: List[FederatedMembers] = []
+
+
+class FederatedRepositoryResponse(FederatedBaseRepostoryModel):
+    """Models a federated repository response (member model differs from request)."""
+
+    members: List[FederatedMembersResponse] = []
     enableComposerSupport: bool = False
     enableNuGetSupport: bool = False
     enableGemsSupport: bool = False

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -47,24 +47,24 @@ UPDATED_REMOTE_REPOSITORY_RESPONSE = RemoteRepositoryResponse(
 FEDERATED_REPOSITORY = FederatedRepository(
     key="test_federated_repository",
     url="http://test-url.com",
-    members=[{"url": "member1.domain.com", "enabled": True}],
+    members=[{"url": "member1.domain.com", "enabled": "true"}],
 )
 FEDERATED_REPOSITORY_RESPONSE = FederatedRepositoryResponse(
     key="test_federated_repository",
     url="http://test-url.com",
-    members=[{"url": "member1.domain.com", "enabled": True}],
+    members=[{"url": "member1.domain.com", "enabled": "true"}],
 )
 UPDATED_FEDERATED_REPOSITORY = FederatedRepository(
     key="test_federated_repository",
     url="http://test-url.com",
     description="updated",
-    members=[{"url": "member1.domain.com", "enabled": True}],
+    members=[{"url": "member1.domain.com", "enabled": "true"}],
 )
 UPDATED_FEDERATED_REPOSITORY_RESPONSE = FederatedRepositoryResponse(
     key="test_federated_repository",
     url="http://test-url.com",
     description="updated",
-    members=[{"url": "member1.domain.com", "enabled": True}],
+    members=[{"url": "member1.domain.com", "enabled": "true"}],
 )
 
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -8,6 +8,8 @@ from pyartifactory import ArtifactoryRepository
 from pyartifactory.exception import RepositoryAlreadyExistsError, RepositoryNotFoundError
 from pyartifactory.models import (
     AuthModel,
+    FederatedRepository,
+    FederatedRepositoryResponse,
     LocalRepository,
     LocalRepositoryResponse,
     RemoteRepository,
@@ -40,6 +42,29 @@ UPDATED_REMOTE_REPOSITORY_RESPONSE = RemoteRepositoryResponse(
     key="test_remote_repository",
     url="http://test-url.com",
     description="updated",
+)
+
+FEDERATED_REPOSITORY = FederatedRepository(
+    key="test_federated_repository",
+    url="http://test-url.com",
+    members=[{"url": "member1.domain.com", "enabled": True}],
+)
+FEDERATED_REPOSITORY_RESPONSE = FederatedRepositoryResponse(
+    key="test_federated_repository",
+    url="http://test-url.com",
+    members=[{"url": "member1.domain.com", "enabled": True}],
+)
+UPDATED_FEDERATED_REPOSITORY = FederatedRepository(
+    key="test_federated_repository",
+    url="http://test-url.com",
+    description="updated",
+    members=[{"url": "member1.domain.com", "enabled": True}],
+)
+UPDATED_FEDERATED_REPOSITORY_RESPONSE = FederatedRepositoryResponse(
+    key="test_federated_repository",
+    url="http://test-url.com",
+    description="updated",
+    members=[{"url": "member1.domain.com", "enabled": True}],
 )
 
 
@@ -98,6 +123,25 @@ def test_create_remote_repository_fail_if_repository_already_exists(
         artifactory_repo.create_repo(REMOTE_REPOSITORY)
 
     artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
+
+
+@responses.activate
+def test_create_federated_repository_fail_if_repository_already_exists(
+    mocker,
+):
+    responses.add(
+        responses.GET,
+        f"{URL}/api/repositories/{FEDERATED_REPOSITORY.key}",
+        json=FEDERATED_REPOSITORY_RESPONSE.model_dump(),
+        status=200,
+    )
+
+    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
+    mocker.spy(artifactory_repo, "get_repo")
+    with pytest.raises(RepositoryAlreadyExistsError):
+        artifactory_repo.create_repo(FEDERATED_REPOSITORY)
+
+    artifactory_repo.get_repo.assert_called_once_with(FEDERATED_REPOSITORY.key)
 
 
 @responses.activate
@@ -171,6 +215,29 @@ def test_create_remote_repository_success(mocker):
 
 
 @responses.activate
+def test_create_federated_repository_success(mocker):
+    responses.add(responses.GET, f"{URL}/api/repositories/{FEDERATED_REPOSITORY.key}", status=404)
+    responses.add(
+        responses.PUT,
+        f"{URL}/api/repositories/{FEDERATED_REPOSITORY.key}",
+        json=FEDERATED_REPOSITORY_RESPONSE.model_dump(),
+        status=201,
+    )
+    responses.add(
+        responses.GET,
+        f"{URL}/api/repositories/{FEDERATED_REPOSITORY.key}",
+        json=FEDERATED_REPOSITORY_RESPONSE.model_dump(),
+        status=200,
+    )
+
+    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
+    mocker.spy(artifactory_repo, "get_repo")
+    federated_repo = artifactory_repo.create_repo(FEDERATED_REPOSITORY)
+
+    assert federated_repo == FEDERATED_REPOSITORY_RESPONSE
+
+
+@responses.activate
 def test_get_local_repository_error_not_found(mocker):
     responses.add(responses.GET, f"{URL}/api/repositories/{LOCAL_REPOSITORY.key}", status=404)
 
@@ -226,6 +293,21 @@ def test_get_remote_repository_success():
 
 
 @responses.activate
+def test_get_federated_repository_success():
+    responses.add(
+        responses.GET,
+        f"{URL}/api/repositories/{FEDERATED_REPOSITORY.key}",
+        json=FEDERATED_REPOSITORY_RESPONSE.model_dump(),
+        status=200,
+    )
+
+    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
+    remote_repo = artifactory_repo.get_repo(FEDERATED_REPOSITORY.key)
+
+    assert remote_repo == FEDERATED_REPOSITORY_RESPONSE
+
+
+@responses.activate
 def test_list_repositories_success(mocker):
     responses.add(
         responses.GET,
@@ -274,6 +356,18 @@ def test_update_remote_repository_fail_if_repo_not_found(mocker):
         artifactory_repo.update_repo(REMOTE_REPOSITORY)
 
     artifactory_repo.get_repo.assert_called_once_with(REMOTE_REPOSITORY.key)
+
+
+@responses.activate
+def test_update_federated_repository_fail_if_repo_not_found(mocker):
+    responses.add(responses.GET, f"{URL}/api/repositories/{FEDERATED_REPOSITORY.key}", status=404)
+
+    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
+    mocker.spy(artifactory_repo, "get_repo")
+    with pytest.raises(RepositoryNotFoundError):
+        artifactory_repo.update_repo(FEDERATED_REPOSITORY)
+
+    artifactory_repo.get_repo.assert_called_once_with(FEDERATED_REPOSITORY.key)
 
 
 @responses.activate
@@ -352,6 +446,31 @@ def test_update_remote_repository_success():
     artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
     updated_repo = artifactory_repo.update_repo(UPDATED_REMOTE_REPOSITORY)
     assert updated_repo == UPDATED_REMOTE_REPOSITORY_RESPONSE
+
+
+@responses.activate
+def test_update_federated_repository_success():
+    responses.add(
+        responses.GET,
+        f"{URL}/api/repositories/{UPDATED_FEDERATED_REPOSITORY.key}",
+        json=UPDATED_FEDERATED_REPOSITORY_RESPONSE.model_dump(),
+        status=200,
+    )
+
+    responses.add(
+        responses.POST,
+        f"{URL}/api/repositories/{UPDATED_FEDERATED_REPOSITORY.key}",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{URL}/api/repositories/{UPDATED_FEDERATED_REPOSITORY.key}",
+        json=UPDATED_FEDERATED_REPOSITORY_RESPONSE.model_dump(),
+        status=200,
+    )
+    artifactory_repo = ArtifactoryRepository(AuthModel(url=URL, auth=AUTH))
+    updated_repo = artifactory_repo.update_repo(UPDATED_FEDERATED_REPOSITORY)
+    assert updated_repo == UPDATED_FEDERATED_REPOSITORY_RESPONSE
 
 
 @responses.activate


### PR DESCRIPTION
## Description

Artifactory provides in a new Type of Repo: `federated`. this is basically a local repo, except that the model has a field members, which contains URLs to other artifactory instances and replicated (bi-directional) the content between these instances

Fixes # (issue)
-

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has it been tested ?

- [x] pytest ;)
- [x] Integration test:
  ```
  from __future__ import annotations

  from pyartifactory import Artifactory
  from pyartifactory.models import FederatedRepository, LocalRepository

  art = Artifactory(
      url="https://URL/artifactory",
      auth=("XXX", "XXX"),
      verify=False,
  )

  # testing of "old" behavior still works fine
  local_repo = LocalRepository(key="local_test")
  new_local_repo = art.repositories.create_repo(local_repo)

  # testing if federated repo creation works
  fed_repo = FederatedRepository(key="test2")
  new_fed_repo = art.repositories.create_repo(fed_repo)
  ```

## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
