### PR TITLE
Added terraform backend and helmoci package types

### DIFF
--- a/pyartifactory/models/repository.py
+++ b/pyartifactory/models/repository.py
@@ -29,6 +29,7 @@ class PackageTypeEnum(str, Enum):
     go = "go"
     gradle = "gradle"
     helm = "helm"
+    helmoci = "helmoci"
     ivy = "ivy"
     maven = "maven"
     npm = "npm"
@@ -40,6 +41,7 @@ class PackageTypeEnum(str, Enum):
     rpm = "rpm"
     sbt = "sbt"
     terraform = "terraform"
+    terraformbackend = "terraformbackend"
     vagrant = "vagrant"
     vcs = "vcs"
     yum = "yum"
@@ -179,6 +181,7 @@ class LocalRepository(BaseRepositoryModel):
     secondaryKeyPairRef: Optional[str] = None
     priorityResolution: bool = False
     cargoInternalIndex: bool = False
+    terraformType: Literal["MODULE", "PROVIDER"] = "MODULE"
 
 
 class LocalRepositoryResponse(LocalRepository):
@@ -352,6 +355,7 @@ class FederatedBaseRepostoryModel(BaseRepositoryModel):
     secondaryKeyPairRef: Optional[str] = None
     priorityResolution: bool = False
     cargoInternalIndex: bool = False
+    terraformType: Literal["MODULE", "PROVIDER"] = "MODULE"
 
 
 class FederatedRepository(FederatedBaseRepostoryModel):


### PR DESCRIPTION
## Description

This PR added 2 repotypes to the library:
* helmoci
* terraformbackend

furthermore it added some typing validation for the terraform repository (`terraformType`), which is a mandatory parameter when adding a terraform repo

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] integration tests:
```
repo = LocalRepository(key="tf-be", packageType="terraformbackend")
newrepo = art.repositories.create_repo(repo)
repo = art.repositories.get_repo("tf-be")
pprint(repo)
art.repositories.delete("tf-be")

print("-----------------")

repo = LocalRepository(key="tf-module", packageType="terraform", terraformType="MODULE")
newrepo = art.repositories.create_repo(repo)
repo = art.repositories.get_repo("tf-module")
pprint(repo)
art.repositories.delete("tf-module")

print("-----------------")

repo = LocalRepository(key="tf-provider", packageType="terraform", terraformType="PROVIDER")
newrepo = art.repositories.create_repo(repo)
repo = art.repositories.get_repo("tf-provider")
pprint(repo)
art.repositories.delete("tf-provider")

print("-----------------")

repo = LocalRepository(key="helmoci", packageType="helmoci")
newrepo = art.repositories.create_repo(repo)
repo = art.repositories.get_repo("helmoci")
pprint(repo)
art.repositories.delete("helmoci")
```

```
Repository tf-be does not exist
LocalRepositoryResponse(key='tf-be', projectKey=None, rclass=<RClassEnum.local: 'local'>, packageType=<PackageTypeEnum.terraformbackend: 'terraformbackend'>, description='', notes='', includesPattern='**/*', excludesPattern='', repoLayoutRef='maven-2-default', checksumPolicyType=<ChecksumPolicyType.client_checksums: 'client-checksums'>, handleReleases=True, handleSnapshots=True, maxUniqueSnapshots=0, maxUniqueTags=0, debianTrivialLayout=False, snapshotVersionBehavior=<SnapshotVersionBehavior.non_unique: 'non-unique'>, suppressPomConsistencyChecks=False, blackedOut=False, xrayIndex=False, propertySets=[], dockerApiVersion='V2', archiveBrowsingEnabled=False, calculateYumMetadata=False, yumRootDepth=0, enableFileListsIndexing=False, optionalIndexCompressionFormats=None, downloadRedirect=False, cdnRedirect=False, blockPushingSchema1=True, primaryKeyPairRef=None, secondaryKeyPairRef=None, priorityResolution=False, cargoInternalIndex=False, terraformType='MODULE', enableComposerSupport=False, enableNuGetSupport=False, enableGemsSupport=False, enableNpmSupport=False, enableBowerSupport=False, enableCocoaPodsSupport=False, enableConanSupport=False, enableDebianSupport=False, enablePypiSupport=False, enablePuppetSupport=False, enableDockerSupport=False, forceNugetAuthentication=False, enableVagrantSupport=False, enableGitLfsSupport=False, enableDistRepoSupport=False)
-----------------
Repository tf-module does not exist
LocalRepositoryResponse(key='tf-module', projectKey=None, rclass=<RClassEnum.local: 'local'>, packageType=<PackageTypeEnum.terraform: 'terraform'>, description='', notes='', includesPattern='**/*', excludesPattern='', repoLayoutRef='maven-2-default', checksumPolicyType=<ChecksumPolicyType.client_checksums: 'client-checksums'>, handleReleases=True, handleSnapshots=True, maxUniqueSnapshots=0, maxUniqueTags=0, debianTrivialLayout=False, snapshotVersionBehavior=<SnapshotVersionBehavior.non_unique: 'non-unique'>, suppressPomConsistencyChecks=False, blackedOut=False, xrayIndex=False, propertySets=[], dockerApiVersion='V2', archiveBrowsingEnabled=False, calculateYumMetadata=False, yumRootDepth=0, enableFileListsIndexing=False, optionalIndexCompressionFormats=None, downloadRedirect=False, cdnRedirect=False, blockPushingSchema1=True, primaryKeyPairRef=None, secondaryKeyPairRef=None, priorityResolution=False, cargoInternalIndex=False, terraformType='MODULE', enableComposerSupport=False, enableNuGetSupport=False, enableGemsSupport=False, enableNpmSupport=False, enableBowerSupport=False, enableCocoaPodsSupport=False, enableConanSupport=False, enableDebianSupport=False, enablePypiSupport=False, enablePuppetSupport=False, enableDockerSupport=False, forceNugetAuthentication=False, enableVagrantSupport=False, enableGitLfsSupport=False, enableDistRepoSupport=False)
-----------------
Repository tf-provider does not exist
LocalRepositoryResponse(key='tf-provider', projectKey=None, rclass=<RClassEnum.local: 'local'>, packageType=<PackageTypeEnum.terraform: 'terraform'>, description='', notes='', includesPattern='**/*', excludesPattern='', repoLayoutRef='maven-2-default', checksumPolicyType=<ChecksumPolicyType.client_checksums: 'client-checksums'>, handleReleases=True, handleSnapshots=True, maxUniqueSnapshots=0, maxUniqueTags=0, debianTrivialLayout=False, snapshotVersionBehavior=<SnapshotVersionBehavior.non_unique: 'non-unique'>, suppressPomConsistencyChecks=False, blackedOut=False, xrayIndex=False, propertySets=[], dockerApiVersion='V2', archiveBrowsingEnabled=False, calculateYumMetadata=False, yumRootDepth=0, enableFileListsIndexing=False, optionalIndexCompressionFormats=None, downloadRedirect=False, cdnRedirect=False, blockPushingSchema1=True, primaryKeyPairRef=None, secondaryKeyPairRef=None, priorityResolution=False, cargoInternalIndex=False, terraformType='PROVIDER', enableComposerSupport=False, enableNuGetSupport=False, enableGemsSupport=False, enableNpmSupport=False, enableBowerSupport=False, enableCocoaPodsSupport=False, enableConanSupport=False, enableDebianSupport=False, enablePypiSupport=False, enablePuppetSupport=False, enableDockerSupport=False, forceNugetAuthentication=False, enableVagrantSupport=False, enableGitLfsSupport=False, enableDistRepoSupport=False)
-----------------
Repository helmoci does not exist
LocalRepositoryResponse(key='helmoci', projectKey=None, rclass=<RClassEnum.local: 'local'>, packageType=<PackageTypeEnum.helmoci: 'helmoci'>, description='', notes='', includesPattern='**/*', excludesPattern='', repoLayoutRef='maven-2-default', checksumPolicyType=<ChecksumPolicyType.client_checksums: 'client-checksums'>, handleReleases=True, handleSnapshots=True, maxUniqueSnapshots=0, maxUniqueTags=0, debianTrivialLayout=False, snapshotVersionBehavior=<SnapshotVersionBehavior.non_unique: 'non-unique'>, suppressPomConsistencyChecks=False, blackedOut=False, xrayIndex=False, propertySets=[], dockerApiVersion='V2', archiveBrowsingEnabled=False, calculateYumMetadata=False, yumRootDepth=0, enableFileListsIndexing=False, optionalIndexCompressionFormats=None, downloadRedirect=False, cdnRedirect=False, blockPushingSchema1=True, primaryKeyPairRef=None, secondaryKeyPairRef=None, priorityResolution=False, cargoInternalIndex=False, terraformType='MODULE', enableComposerSupport=False, enableNuGetSupport=False, enableGemsSupport=False, enableNpmSupport=False, enableBowerSupport=False, enableCocoaPodsSupport=False, enableConanSupport=False, enableDebianSupport=False, enablePypiSupport=False, enablePuppetSupport=False, enableDockerSupport=True, forceNugetAuthentication=False, enableVagrantSupport=False, enableGitLfsSupport=False, enableDistRepoSupport=False)
```


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [ ] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [x] Automated tests are green (see pipeline)
