### PR TITLE
Add support for deleting all artifact properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Retrieve artifact properties](#retrieve-artifact-properties)
     + [Set artifact properties](#set-artifact-properties)
     + [Update artifact properties](#update-artifact-properties)
+    + [Delete all artifact properties](#delete-all-artifact-properties)
     + [Retrieve artifact stats](#retrieve-artifact-stats)
     + [Copy artifact to a new location](#copy-artifact-to-a-new-location)
     + [Move artifact to a new location](#move-artifact-to-a-new-location)
@@ -423,6 +424,11 @@ artifact_properties = art.artifacts.set_properties("<ARTIFACT_PATH_IN_ARTIFACTOR
 ```python
 artifact_properties = art.artifacts.update_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", {"prop1": ["value"], "prop2": ["value1", "value2", "etc"})  # recursive mode is enabled by default
 artifact_properties = art.artifacts.update_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>", {"prop1": ["value"], "prop2": ["value1", "value2", "etc"}, False) # disable recursive mode
+```
+
+#### Delete all artifact properties
+```python
+artifact_properties = art.artifacts.delete_properties("<ARTIFACT_PATH_IN_ARTIFACTORY>")
 ```
 
 #### Retrieve artifact stats

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -247,6 +247,26 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 raise BadPropertiesError("A property value includes forbidden special characters")
             raise ArtifactoryError from error
 
+    def delete_properties(
+        self,
+        artifact_path: str,
+    ) -> ArtifactPropertiesResponse:
+        """
+        Deletes ALL properties of an artifact
+        :param artifact_path: Path to file or folder in Artifactory
+        :return: None
+        """
+        artifact_path = artifact_path.lstrip("/")
+        try:
+            self._delete(f"api/metadata/{artifact_path}")
+            logger.debug("Artifact Properties successfully deleted")
+            return ArtifactPropertiesResponse(uri=artifact_path, properties={})
+        except requests.exceptions.HTTPError as error:
+            http_response: Union[Response, None] = error.response
+            if isinstance(http_response, Response) and http_response.status_code == 404:
+                raise PropertyNotFoundError(f"No properties could be found on artifact {artifact_path}")
+            raise ArtifactoryError from error
+
     def update_properties(
         self,
         artifact_path: str,


### PR DESCRIPTION
## Description
The new `delete_properties` nukes all properties of the artifact. This is very helpful to remove a big list of properties, specially when we don't exactly know the key name of all of them.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## How has it been tested ?
- Tested manually against the company's enterprise Artifactory
- Added unit test for future regression testing.

## Checklist:

- [X] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [X] All commits have a correct title
- [X] Readme has been updated
- [X] Quality tests are green (see Codacy)
- [X] Automated tests are green (see pipeline)
