### PR TITLE
Fix recursive parameter

### DIFF
--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -265,7 +265,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         try:
             self._patch(
                 f"api/metadata/{artifact_path}",
-                params={"recursive": int(recursive)},
+                params={"recursiveProperties": int(recursive)},
                 headers={"Content-Type": "application/json"},
                 json={"props": properties},
             )


### PR DESCRIPTION
## Description

According  to the [documentation](https://jfrog.com/help/r/jfrog-rest-apis/update-item-properties), the recursive parameter should be "recursiveProperties" not "recursive". (Update api only)

https://jfrog.com/help/r/jfrog-rest-apis/update-item-properties