### PR TITLE
Fix timeout: Add timeout parameter on Artifactory constructor too

### DIFF
--- a/pyartifactory/objects/artifactory.py
+++ b/pyartifactory/objects/artifactory.py
@@ -23,8 +23,16 @@ class Artifactory:
         verify: Union[bool, str] = True,
         cert: Optional[str] = None,
         api_version: int = 1,
+        timeout: Optional[int] = None,
     ):
-        self.artifactory = AuthModel(url=url, auth=auth, verify=verify, cert=cert, api_version=api_version)
+        self.artifactory = AuthModel(
+            url=url,
+            auth=auth,
+            verify=verify,
+            cert=cert,
+            api_version=api_version,
+            timeout=timeout,
+        )
         self.users = ArtifactoryUser(self.artifactory)
         self.groups = ArtifactoryGroup(self.artifactory)
         self.security = ArtifactorySecurity(self.artifactory)


### PR DESCRIPTION
## Description

I forgot to add the timeout parameter to the Artifactory class in my previous pull request. It was only added to the ArtifactoryObject constructor. As a result, we can't initialize an Artifactory instance with a timeout, and it must be set on the artifactory attribute after initialization. This PR adds the timeout parameter to the Artifactory init function, and the timeout should now be usable as described in the documentation.

sorry for the mistake.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

No new unit test.


## Checklist:

- [X] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [X] All commits have a correct title
- [X] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [X] Automated tests are green (see pipeline)
