### PR TITLE
fix: convert password to str for create_remote_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ virtual_repo = VirtualRepository(key="test_virtual_repo")
 new_virtual_repo = art.repositories.create_repo(virtual_repo)
 
 # Create remote repo
-remote_repo = RemoteRepository(key="test_remote_repo")
+remote_repo = RemoteRepository(key="test_remote_repo", url="http://test-url.com")
 new_remote_repo = art.repositories.create_repo(remote_repo)
 
 # Create federated repo

--- a/pyartifactory/objects/repository.py
+++ b/pyartifactory/objects/repository.py
@@ -102,7 +102,7 @@ class ArtifactoryRepository(ArtifactoryObject):
             logger.error("Repository %s already exists", repo_name)
             raise RepositoryAlreadyExistsError(f"Repository {repo_name} already exists")
         except RepositoryNotFoundError:
-            data = json.dumps(repo, default=custom_encoder)
+            data = json.dumps(repo.model_dump(), default=custom_encoder)
             self._put(
                 f"api/{self._uri}/{repo_name}",
                 headers={"Content-Type": "application/json"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyArtifactory"
-version = "2.5.0"
+version = "2.5.1"
 description = "Typed interactions with the Jfrog Artifactory REST API"
 authors = [
     "Ananias CARVALHO <carvalhoananias@hotmail.com>",


### PR DESCRIPTION
## Description

When creating a repository with a password, this password is transmitted as stars only in the REST request:
"password": "**********"

Fixes #179 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
