### PR TITLE
fix: make email in UserResponse optional

### DIFF
--- a/pyartifactory/models/user.py
+++ b/pyartifactory/models/user.py
@@ -47,7 +47,7 @@ class User(BaseUserModel):
 class UserResponse(BaseUserModel):
     """Models a user response."""
 
-    email: EmailStr
+    email: Optional[EmailStr] = None
     lastLoggedIn: Optional[datetime] = None
     realm: Optional[str] = None
     offlineMode: bool = False


### PR DESCRIPTION
## Description

I'm trying to get a User from an enterprise Artifactory instance, but I'm getting the following error:
```
>>> art.users.get("username")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyartifactory/objects/user.py", line 48, in get
    return UserResponse(**response.json())
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pydantic/main.py", line 193, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for UserResponse
email
  Field required [type=missing, input_value={'name': 'username', 'admin'..., 'shouldInvite': False}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.8/v/missing
```

and when I query that user manually, I don't see an email field in the response from Artifactory. It's most likely because we get users using Okta, so email never gets set.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has it been tested ?

I cloned my fork, ran the poetry install setup in CONTRIBUTING.md, and tried getting the same user. I was able to get the user through this method.


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [ ] All commits have a correct title
- [ ] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
