### PR TITLE
Deploy properties along with artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTI
 
 ```python
 artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>", "<PROPERTIES>")
-# artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt", {"retention": "30"})
+# artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt", {"retention": ["30"]})
 ```
 
 #### Deploy an artifact with checksums

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This library enables you to manage Artifactory resources such as users, groups, 
   * [Artifacts](#artifacts)
     + [Get the information about a file or folder](#get-the-information-about-a-file-or-folder)
     + [Deploy an artifact](#deploy-an-artifact)
+    + [Deploy an artifact with properties](#deploy-an-artifact-with-properties)
     + [Deploy an artifact with checksums](#deploy-an-artifact-with-checksums)
     + [Download an artifact](#download-an-artifact)
     + [Retrieve artifact list](#retrieve-artifact-list)
@@ -401,6 +402,13 @@ artifact_info = art.artifacts.info("<ARTIFACT_PATH_IN_ARTIFACTORY>")
 ```python
 artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>")
 # artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt")
+```
+
+#### Deploy an artifact with properties
+
+```python
+artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>", "<PROPERTIES>")
+# artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt", {"retention": "30"})
 ```
 
 #### Deploy an artifact with checksums

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -121,9 +121,9 @@ class ArtifactoryArtifact(ArtifactoryObject):
                     raise ArtifactoryError from error
             else:
                 with local_file.open("rb") as stream:
-                    if properties is None:
-                        properties = {}
-                    properties_param_str = self._format_properties(properties)
+                    properties_param_str = ""
+                    if properties is not None:
+                        properties_param_str = self._format_properties(properties)
                     route = ";".join(s for s in [artifact_folder.as_posix(), properties_param_str] if s)
                     self._put(route, data=stream)
 
@@ -220,8 +220,8 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 logger.error("Artifact %s does not exist", artifact_path)
                 raise ArtifactNotFoundError(f"Artifact {artifact_path} does not exist")
             raise ArtifactoryError from error
-        
-    def _format_properties(self, properties: Optional[List[str]] = None):
+
+    def _format_properties(self, properties: Dict[str, List[str]]):
         properties_param_str = ""
         for k, v in properties.items():
             values_str = ",".join(v)

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -226,7 +226,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         for k, v in properties.items():
             values_str = ",".join(v)
             properties_param_str += f"{k}={values_str};"
-        return properties_param_str
+        return properties_param_str.rstrip(";")
 
     def properties(self, artifact_path: str, properties: Optional[List[str]] = None) -> ArtifactPropertiesResponse:
         """

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -80,6 +80,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         self,
         local_file_location: Union[Path, str],
         artifact_path: Union[Path, str],
+        properties: Optional[Dict[str, List[str]]] = None,
         checksum_enabled: bool = False,
     ) -> ArtifactInfoResponse:
         """
@@ -95,7 +96,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
             for root, _, files in os.walk(local_file.as_posix()):
                 new_root = f"{artifact_folder}/{root[len(local_file.as_posix()):]}"
                 for file in files:
-                    self.deploy(Path(f"{root}/{file}"), Path(f"{new_root}/{file}"), checksum_enabled)
+                    self.deploy(Path(f"{root}/{file}"), Path(f"{new_root}/{file}"), properties, checksum_enabled)
         else:
             if checksum_enabled:
                 artifact_check_sums = Checksums.generate(local_file)
@@ -120,7 +121,11 @@ class ArtifactoryArtifact(ArtifactoryObject):
                     raise ArtifactoryError from error
             else:
                 with local_file.open("rb") as stream:
-                    self._put(route=artifact_folder.as_posix(), data=stream)
+                    if properties is None:
+                        properties = {}
+                    properties_param_str = self._format_properties(properties)
+                    route = ";".join(s for s in [artifact_folder.as_posix(), properties_param_str] if s)
+                    self._put(route, data=stream)
 
             logger.debug("Artifact %s successfully deployed", local_file)
         return self.info(artifact_folder)
@@ -215,6 +220,13 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 logger.error("Artifact %s does not exist", artifact_path)
                 raise ArtifactNotFoundError(f"Artifact {artifact_path} does not exist")
             raise ArtifactoryError from error
+        
+    def _format_properties(self, properties: Optional[List[str]] = None):
+        properties_param_str = ""
+        for k, v in properties.items():
+            values_str = ",".join(v)
+            properties_param_str += f"{k}={values_str};"
+        return properties_param_str
 
     def properties(self, artifact_path: str, properties: Optional[List[str]] = None) -> ArtifactPropertiesResponse:
         """
@@ -253,10 +265,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         if properties is None:
             properties = {}
         artifact_path = artifact_path.lstrip("/")
-        properties_param_str = ""
-        for k, v in properties.items():
-            values_str = ",".join(v)
-            properties_param_str += f"{k}={values_str};"
+        properties_param_str = self._format_properties(properties)
         try:
             self._put(
                 f"api/storage/{artifact_path}",

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -448,8 +448,13 @@ def test_deploy_artifact_with_properties_success():
         status=200,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    artifactory.deploy(Path(LOCAL_FILE_LOCATION), Path(ARTIFACT_PATH), properties=ARTIFACT_ONE_PROPERTY.properties, checksum_enabled=False)
-    artifact_properties = artifactory.properties(ARTIFACT_PATH,["prop1"])
+    artifactory.deploy(
+        Path(LOCAL_FILE_LOCATION),
+        Path(ARTIFACT_PATH),
+        properties=ARTIFACT_ONE_PROPERTY.properties,
+        checksum_enabled=False,
+    )
+    artifact_properties = artifactory.properties(ARTIFACT_PATH, ["prop1"])
     assert artifact_properties.model_dump() == ARTIFACT_ONE_PROPERTY.model_dump()
 
 
@@ -457,8 +462,8 @@ def test_deploy_artifact_with_properties_success():
 def test_deploy_artifact_with_multiple_properties_success():
     properties_param_str = ""
     for k, v in ARTIFACT_MULTIPLE_PROPERTIES.properties.items():
-        values_str = f",".join(list(map(urllib.parse.quote, v)))
-        properties_param_str +=f"{k}={values_str};"
+        values_str = ",".join(list(map(urllib.parse.quote, v)))
+        properties_param_str += f"{k}={values_str};"
     responses.add(
         responses.PUT,
         f"{URL}/{ARTIFACT_PATH};{properties_param_str}",
@@ -477,9 +482,15 @@ def test_deploy_artifact_with_multiple_properties_success():
         status=200,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    artifactory.deploy(Path(LOCAL_FILE_LOCATION), Path(ARTIFACT_PATH), properties=ARTIFACT_MULTIPLE_PROPERTIES.properties, checksum_enabled=False)
-    artifact_properties = artifactory.properties(ARTIFACT_PATH,["prop1", "prop2"])
+    artifactory.deploy(
+        Path(LOCAL_FILE_LOCATION),
+        Path(ARTIFACT_PATH),
+        properties=ARTIFACT_MULTIPLE_PROPERTIES.properties,
+        checksum_enabled=False,
+    )
+    artifact_properties = artifactory.properties(ARTIFACT_PATH, ["prop1", "prop2"])
     assert artifact_properties.model_dump() == ARTIFACT_MULTIPLE_PROPERTIES.model_dump()
+
 
 @responses.activate
 def test_set_property_fail_artifact_not_found():

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -410,7 +410,7 @@ def test_set_property_success():
         properties_param_str += urllib.parse.quote_plus(f"{k}={values_str};")
     responses.add(
         responses.PUT,
-        f"{URL}/api/storage/{ARTIFACT_PATH}?recursive=1&properties={properties_param_str}",
+        f"{URL}/api/storage/{ARTIFACT_PATH}?recursive=1&properties={properties_param_str.rstrip('%3B')}",
         status=200,
     )
     responses.add(
@@ -432,7 +432,7 @@ def test_deploy_artifact_with_properties_success():
         properties_param_str += f"{k}={values_str};"
     responses.add(
         responses.PUT,
-        f"{URL}/{ARTIFACT_PATH};{properties_param_str}",
+        f"{URL}/{ARTIFACT_PATH};{properties_param_str.rstrip(';')}",
         status=200,
     )
     responses.add(
@@ -466,7 +466,7 @@ def test_deploy_artifact_with_multiple_properties_success():
         properties_param_str += f"{k}={values_str};"
     responses.add(
         responses.PUT,
-        f"{URL}/{ARTIFACT_PATH};{properties_param_str}",
+        f"{URL}/{ARTIFACT_PATH};{properties_param_str.rstrip(';')}",
         status=200,
     )
     responses.add(
@@ -500,7 +500,7 @@ def test_set_property_fail_artifact_not_found():
         properties_param_str += urllib.parse.quote_plus(f"{k}={values_str};")
     responses.add(
         responses.PUT,
-        f"{URL}/api/storage/{NX_ARTIFACT_PATH}?recursive=1&properties={properties_param_str}",
+        f"{URL}/api/storage/{NX_ARTIFACT_PATH}?recursive=1&properties={properties_param_str.rstrip('%3B')}",
         status=404,
     )
     artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
@@ -511,7 +511,7 @@ def test_set_property_fail_artifact_not_found():
 
 @responses.activate
 def test_set_property_fail_bad_value():
-    properties_param_str = urllib.parse.quote_plus(f"{BAD_PROPERTY_NAME}={BAD_PROPERTY_VALUE};")
+    properties_param_str = urllib.parse.quote_plus(f"{BAD_PROPERTY_NAME}={BAD_PROPERTY_VALUE}")
     responses.add(
         responses.PUT,
         f"{URL}/api/storage/{ARTIFACT_PATH}?recursive=1&properties={properties_param_str}",


### PR DESCRIPTION
## Description

Artifactory REST API supports deploying artifacts and properties in a single operation. This is particularly useful so that you don't have to make any additional API calls to set properties.

This PR enables the deployment of artifacts and properties (optional parameter) in the same request.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
