### PR TITLE
fix: support new create access token API

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,17 +204,9 @@ art.security.create_api_key(          art.security.get_encrypted_password(  art.
 art.security.get_api_key(             art.security.regenerate_api_key(      art.security.revoke_user_api_key(
 ```
 
-Create an access token (for a transient user):
+Create an access token:
 ```python
-token = art.security.create_access_token(user_name='transient_artifactory_user',
-                                         groups=['g1', 'g2'],
-                                         refreshable=True)
-```
-
-Create an access token for an existing user (groups are implied from the existing user):
-```python
-token = art.security.create_access_token(user_name='existing_artifactory_user',
-                                         refreshable=True)
+token = art.security.create_access_token(user_name='artifactory_user', refreshable=True, scope="applied-permissions/user")
 ```
 
 Revoke an existing revocable token:


### PR DESCRIPTION
## Description

Support the new `/access/api/v1/tokens` REST API to create access tokens (See [documentation](https://jfrog.com/help/r/jfrog-rest-apis/create-token)).

The old Create Token API that is used by ArtifactorySecurity.create_access_token() is deprecated: https://jfrog.com/help/r/jfrog-rest-apis/create-token-deprecated

Tokens created using the old API can't be used to authenticate with the new API due to audience limitations in old tokens.

Fixes #150

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
