### PR TITLE
fix: re-order access_token param in Artifactory object

### DIFF
--- a/pyartifactory/objects/artifactory.py
+++ b/pyartifactory/objects/artifactory.py
@@ -21,11 +21,11 @@ class Artifactory:
         self,
         url: str,
         auth: Optional[Tuple[str, SecretStr]] = None,
-        access_token: Optional[str] = None,
         verify: Union[bool, str] = True,
         cert: Optional[str] = None,
         api_version: int = 1,
         timeout: Optional[int] = None,
+        access_token: Optional[str] = None,
     ):
         self.artifactory = AuthModel(
             url=url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyArtifactory"
-version = "2.7.0"
+version = "2.7.1"
 description = "Typed interactions with the Jfrog Artifactory REST API"
 authors = [
     "Ananias CARVALHO <carvalhoananias@hotmail.com>",


### PR DESCRIPTION
## Description

v2.7.0 added a new parameter (access_token) in the middle of the Artifactory class constructor, breaking backward compatibility.

Fixes #197

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)