### PR TITLE
Pass the artifacts checksums in the headers of the deploy request

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Deploy an artifact](#deploy-an-artifact)
     + [Deploy an artifact with properties](#deploy-an-artifact-with-properties)
     + [Deploy an artifact with checksums](#deploy-an-artifact-with-checksums)
+    + [Deploy an artifact by checksums](#deploy-an-artifact-by-checksums)
     + [Download an artifact](#download-an-artifact)
     + [Retrieve artifact list](#retrieve-artifact-list)
     + [Retrieve artifact properties](#retrieve-artifact-properties)
@@ -425,6 +426,16 @@ artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTI
 ```
 
 #### Deploy an artifact with checksums
+
+```python
+artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>", "<CHECKSUM_ALGORITHMS>")
+# artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt", checksum_algorithms=["md5", "sha1", "sha256"] )
+```
+
+Provides locally calculated checksums for files during deployment so that Artifactory can verify the authenticity of artifacts.
+
+
+#### Deploy an artifact by checksums
 
 ```python
 artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>", checksum_enabled=True)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Get the information about a file or folder](#get-the-information-about-a-file-or-folder)
     + [Deploy an artifact](#deploy-an-artifact)
     + [Deploy an artifact with properties](#deploy-an-artifact-with-properties)
-    + [Deploy an artifact with checksums](#deploy-an-artifact-with-checksums)
     + [Deploy an artifact by checksums](#deploy-an-artifact-by-checksums)
     + [Download an artifact](#download-an-artifact)
     + [Retrieve artifact list](#retrieve-artifact-list)
@@ -424,16 +423,6 @@ artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTI
 artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>", "<PROPERTIES>")
 # artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt", {"retention": ["30"]})
 ```
-
-#### Deploy an artifact with checksums
-
-```python
-artifact = art.artifacts.deploy("<LOCAL_FILE_LOCATION>", "<ARTIFACT_PATH_IN_ARTIFACTORY>", "<CHECKSUM_ALGORITHMS>")
-# artifact = art.artifacts.deploy("Desktop/myNewFile.txt", "my-repository/my/new/artifact/directory/file.txt", checksum_algorithms=["md5", "sha1", "sha256"] )
-```
-
-Provides locally calculated checksums for files during deployment so that Artifactory can verify the authenticity of artifacts.
-
 
 #### Deploy an artifact by checksums
 

--- a/pyartifactory/exception.py
+++ b/pyartifactory/exception.py
@@ -58,3 +58,7 @@ class InvalidTokenDataError(ArtifactoryError):
 
 class BuildNotFoundError(ArtifactoryError):
     """Requested build were not found"""
+
+
+class InvalidAlgorithmError(ArtifactoryError):
+    """The Algoritnm is not supported by Artifactory."""

--- a/pyartifactory/exception.py
+++ b/pyartifactory/exception.py
@@ -58,7 +58,3 @@ class InvalidTokenDataError(ArtifactoryError):
 
 class BuildNotFoundError(ArtifactoryError):
     """Requested build were not found"""
-
-
-class InvalidAlgorithmError(ArtifactoryError):
-    """The Algoritnm is not supported by Artifactory."""

--- a/pyartifactory/models/artifact.py
+++ b/pyartifactory/models/artifact.py
@@ -40,8 +40,8 @@ class OriginalChecksums(BaseModel):
     """Models original checksums."""
 
     sha256: str
-    sha1: Optional[str] = None
-    md5: Optional[str] = None
+    sha1: str
+    md5: str
 
 
 class Child(BaseModel):

--- a/pyartifactory/models/artifact.py
+++ b/pyartifactory/models/artifact.py
@@ -10,28 +10,33 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel
 
+from pyartifactory.exception import InvalidAlgorithmError
+
 
 class Checksums(BaseModel):
     """Models a checksum."""
 
-    sha1: str
-    md5: str
-    sha256: str
+    sha1: Optional[str] = None
+    md5: Optional[str] = None
+    sha256: Optional[str] = None
 
     @classmethod
-    def generate(cls, file_: Path) -> Checksums:
+    def generate(cls, file_: Path, algorithms: List[str] = ["sha1", "sha256", "md5"]) -> Checksums:
         block_size: int = 65536
         mapping: dict[str, Callable[[], Any]] = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256}
         results = {}
 
-        for algorithm, hashing_function in mapping.items():
-            hasher = hashing_function()
-            with file_.absolute().open("rb") as fd:
-                buf = fd.read(block_size)
-                while len(buf) > 0:
-                    hasher.update(buf)
+        for algorithm in algorithms:
+            if algorithm in mapping:
+                hasher = mapping[algorithm]()
+                with file_.absolute().open("rb") as fd:
                     buf = fd.read(block_size)
-            results[algorithm] = hasher.hexdigest()
+                    while len(buf) > 0:
+                        hasher.update(buf)
+                        buf = fd.read(block_size)
+                results[algorithm] = hasher.hexdigest()
+            else:
+                raise InvalidAlgorithmError(f"'{algorithm}' is not a supported checksum algorithm")
 
         return cls(**results)
 
@@ -40,6 +45,8 @@ class OriginalChecksums(BaseModel):
     """Models original checksums."""
 
     sha256: str
+    sha1: Optional[str] = None
+    md5: Optional[str] = None
 
 
 class Child(BaseModel):

--- a/pyartifactory/models/artifact.py
+++ b/pyartifactory/models/artifact.py
@@ -21,7 +21,7 @@ class Checksums(BaseModel):
     sha256: Optional[str] = None
 
     @classmethod
-    def generate(cls, file_: Path, algorithms: List[str] = ["sha1", "sha256", "md5"]) -> Checksums:
+    def generate(cls, file_: Path, algorithms: List[str]) -> Checksums:
         block_size: int = 65536
         mapping: dict[str, Callable[[], Any]] = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256}
         results = {}

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -100,7 +100,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         else:
             properties_param_str = ""
             if properties is not None:
-                properties_param_str = self._format_properties(properties)
+                properties_param_str = ";".join(f"{k}={value}" for k, values in properties.items() for value in values)
             route = ";".join(s for s in [artifact_folder.as_posix(), properties_param_str] if s)
             artifact_check_sums = Checksums.generate(local_file)
             headers = {

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -125,6 +125,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
                         raise ArtifactNotFoundError(message)
                     raise ArtifactoryError from error
             else:
+                headers["X-Checksum-Deploy"] = "false"
                 with local_file.open("rb") as stream:
                     self._put(route=route, headers=headers, data=stream)
 

--- a/pyartifactory/objects/artifact.py
+++ b/pyartifactory/objects/artifact.py
@@ -82,6 +82,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
         artifact_path: Union[Path, str],
         properties: Optional[Dict[str, List[str]]] = None,
         checksum_enabled: bool = False,
+        checksum_algorithms: Optional[List[str]] = None,
     ) -> ArtifactInfoResponse:
         """
         Deploy a file or directory.
@@ -98,17 +99,30 @@ class ArtifactoryArtifact(ArtifactoryObject):
                 for file in files:
                     self.deploy(Path(f"{root}/{file}"), Path(f"{new_root}/{file}"), properties, checksum_enabled)
         else:
+            checksum_headers: Dict[str, str] = {}
+
             if checksum_enabled:
-                artifact_check_sums = Checksums.generate(local_file)
+                checksum_headers["X-Checksum-Deploy"] = "true"
+                checksum_algorithms = ["sha1", "sha256", "md5"]
+
+            if checksum_algorithms is not None:
+                artifact_check_sums = Checksums.generate(local_file, checksum_algorithms)
+                if artifact_check_sums.md5:
+                    checksum_headers["X-Checksum"] = artifact_check_sums.md5
+                if artifact_check_sums.sha1:
+                    checksum_headers["X-Checksum-Sha1"] = artifact_check_sums.sha1
+                if artifact_check_sums.sha256:
+                    checksum_headers["X-Checksum-Sha256"] = artifact_check_sums.sha256
+
+            if checksum_enabled:
                 try:
+                    properties_param_str = ""
+                    if properties is not None:
+                        properties_param_str = self._format_properties(properties)
+                    route = ";".join(s for s in [artifact_folder.as_posix(), properties_param_str] if s)
                     self._put(
-                        route=artifact_folder.as_posix(),
-                        headers={
-                            "X-Checksum-Deploy": "true",
-                            "X-Checksum-Sha1": artifact_check_sums.sha1,
-                            "X-Checksum-Sha256": artifact_check_sums.sha256,
-                            "X-Checksum": artifact_check_sums.md5,
-                        },
+                        route=route,
+                        headers=checksum_headers,
                     )
                 except requests.exceptions.HTTPError as error:
                     if error.response.status_code == 404:
@@ -125,7 +139,7 @@ class ArtifactoryArtifact(ArtifactoryObject):
                     if properties is not None:
                         properties_param_str = self._format_properties(properties)
                     route = ";".join(s for s in [artifact_folder.as_posix(), properties_param_str] if s)
-                    self._put(route, data=stream)
+                    self._put(route=route, headers=checksum_headers, data=stream)
 
             logger.debug("Artifact %s successfully deployed", local_file)
         return self.info(artifact_folder)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -464,10 +464,9 @@ def test_deploy_artifact_with_properties_success():
 
 @responses.activate
 def test_deploy_artifact_with_multiple_properties_success():
-    properties_param_str = ""
-    for k, v in ARTIFACT_MULTIPLE_PROPERTIES.properties.items():
-        values_str = ",".join(list(map(urllib.parse.quote, v)))
-        properties_param_str += f"{k}={values_str};"
+    properties_param_str = ";".join(
+        f"{k}={value}" for k, values in ARTIFACT_MULTIPLE_PROPERTIES.properties.items() for value in values
+    )
     responses.add(
         responses.PUT,
         f"{URL}/{ARTIFACT_PATH};{properties_param_str.rstrip(';')}",

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -16,6 +16,7 @@ from pyartifactory.models.artifact import (
     ArtifactListFolderResponse,
     ArtifactListResponse,
     Checksums,
+    OriginalChecksums,
 )
 
 URL = "http://localhost:8080/artifactory"
@@ -607,6 +608,113 @@ def test_checksum_defined_file(file_path: Path, expected_sha1: str, expected_md5
         sha256=expected_sha256,
     )
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "file_info,expected_checksums",
+    [
+        pytest.param(
+            {
+                **FILE_INFO_RESPONSE.copy(),
+                "originalChecksums": {
+                    "md5": "4cf609e0fe1267df8815bc650f5851e9",
+                    "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+                },
+            },
+            {
+                "md5": "4cf609e0fe1267df8815bc650f5851e9",
+                "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+            },
+            id="md5",
+        ),
+        pytest.param(
+            {
+                **FILE_INFO_RESPONSE.copy(),
+                "originalChecksums": {
+                    "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
+                    "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+                },
+            },
+            {
+                "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
+                "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+            },
+            id="sha1",
+        ),
+        pytest.param(
+            {
+                **FILE_INFO_RESPONSE.copy(),
+                "originalChecksums": {"sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858"},
+            },
+            {"sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858"},
+            id="sha256",
+        ),
+        pytest.param(
+            {
+                **FILE_INFO_RESPONSE.copy(),
+                "originalChecksums": {
+                    "md5": "4cf609e0fe1267df8815bc650f5851e9",
+                    "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
+                    "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+                },
+            },
+            {
+                "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+                "md5": "4cf609e0fe1267df8815bc650f5851e9",
+                "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
+            },
+            id="md5&sha1",
+        ),
+    ],
+)
+@responses.activate
+def test_deploy_artifact_with_checksum_algorithms_success(file_info: dict, expected_checksums: dict):
+    responses.add(responses.PUT, f"{URL}/{ARTIFACT_PATH}", status=200)
+    responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_PATH}",
+        json=file_info,
+        status=200,
+    )
+    expected = OriginalChecksums(**expected_checksums)
+    artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
+    artifact = artifactory.deploy(
+        Path(LOCAL_FILE_LOCATION),
+        Path(ARTIFACT_PATH),
+        checksum_algorithms=file_info["originalChecksums"].keys(),
+    )
+    assert expected == artifact.originalChecksums
+
+
+@pytest.mark.parametrize(
+    "file_info",
+    [
+        pytest.param(
+            {
+                **FILE_INFO_RESPONSE.copy(),
+                "originalChecksums": {"sha224": "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f"},
+            },
+            id="sha224",
+        ),
+    ],
+)
+@responses.activate
+def test_deploy_artifact_with_checksum_algorithms_error(file_info: dict):
+    responses.add(responses.PUT, f"{URL}/{ARTIFACT_PATH}", status=409)
+
+    responses.add(
+        responses.GET,
+        f"{URL}/api/storage/{ARTIFACT_PATH}",
+        json=file_info,
+        status=200,
+    )
+    with pytest.raises(Exception):
+        artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
+        artifactory.deploy(
+            Path(LOCAL_FILE_LOCATION),
+            Path(ARTIFACT_PATH),
+            checksum_algorithms=file_info["originalChecksums"].keys(),
+        )
 
 
 @responses.activate

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -601,7 +601,7 @@ def test_update_property_fail_bad_value():
     ],
 )
 def test_checksum_defined_file(file_path: Path, expected_sha1: str, expected_md5: str, expected_sha256: str):
-    result = Checksums.generate(file_path)
+    result = Checksums.generate(file_path, ["sha1", "sha256", "md5"])
     expected = Checksums(
         sha1=expected_sha1,
         md5=expected_md5,

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -16,7 +16,6 @@ from pyartifactory.models.artifact import (
     ArtifactListFolderResponse,
     ArtifactListResponse,
     Checksums,
-    OriginalChecksums,
 )
 
 URL = "http://localhost:8080/artifactory"
@@ -77,7 +76,11 @@ FILE_INFO_RESPONSE = {
         "md5": "4cf609e0fe1267df8815bc650f5851e9",
         "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
     },
-    "originalChecksums": {"sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858"},
+    "originalChecksums": {
+        "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
+        "md5": "4cf609e0fe1267df8815bc650f5851e9",
+        "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
+    },
     "uri": f"{URL}/api/storage/{ARTIFACT_PATH}",
 }
 FILE_INFO = ArtifactFileInfoResponse(**FILE_INFO_RESPONSE)
@@ -608,81 +611,6 @@ def test_checksum_defined_file(file_path: Path, expected_sha1: str, expected_md5
         sha256=expected_sha256,
     )
     assert result == expected
-
-
-@pytest.mark.parametrize(
-    "file_info,expected_checksums",
-    [
-        pytest.param(
-            {
-                **FILE_INFO_RESPONSE.copy(),
-                "originalChecksums": {
-                    "md5": "4cf609e0fe1267df8815bc650f5851e9",
-                    "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
-                },
-            },
-            {
-                "md5": "4cf609e0fe1267df8815bc650f5851e9",
-                "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
-            },
-            id="md5",
-        ),
-        pytest.param(
-            {
-                **FILE_INFO_RESPONSE.copy(),
-                "originalChecksums": {
-                    "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
-                    "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
-                },
-            },
-            {
-                "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
-                "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
-            },
-            id="sha1",
-        ),
-        pytest.param(
-            {
-                **FILE_INFO_RESPONSE.copy(),
-                "originalChecksums": {"sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858"},
-            },
-            {"sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858"},
-            id="sha256",
-        ),
-        pytest.param(
-            {
-                **FILE_INFO_RESPONSE.copy(),
-                "originalChecksums": {
-                    "md5": "4cf609e0fe1267df8815bc650f5851e9",
-                    "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
-                    "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
-                },
-            },
-            {
-                "sha256": "396cf16e8ce000342c95ffc7feb2a15701d0994b70c1b13fea7112f85ac8e858",
-                "md5": "4cf609e0fe1267df8815bc650f5851e9",
-                "sha1": "962c287c760e03b03c17eb920f5358d05f44dd3b",
-            },
-            id="md5&sha1",
-        ),
-    ],
-)
-@responses.activate
-def test_deploy_artifact_with_checksum_algorithms_success(file_info: dict, expected_checksums: dict):
-    responses.add(responses.PUT, f"{URL}/{ARTIFACT_PATH}", status=200)
-    responses.add(
-        responses.GET,
-        f"{URL}/api/storage/{ARTIFACT_PATH}",
-        json=file_info,
-        status=200,
-    )
-    expected = OriginalChecksums(**expected_checksums)
-    artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-    artifact = artifactory.deploy(
-        Path(LOCAL_FILE_LOCATION),
-        Path(ARTIFACT_PATH),
-    )
-    assert expected == artifact.originalChecksums
 
 
 @responses.activate

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -601,7 +601,7 @@ def test_update_property_fail_bad_value():
     ],
 )
 def test_checksum_defined_file(file_path: Path, expected_sha1: str, expected_md5: str, expected_sha256: str):
-    result = Checksums.generate(file_path, ["sha1", "sha256", "md5"])
+    result = Checksums.generate(file_path)
     expected = Checksums(
         sha1=expected_sha1,
         md5=expected_md5,
@@ -681,40 +681,8 @@ def test_deploy_artifact_with_checksum_algorithms_success(file_info: dict, expec
     artifact = artifactory.deploy(
         Path(LOCAL_FILE_LOCATION),
         Path(ARTIFACT_PATH),
-        checksum_algorithms=file_info["originalChecksums"].keys(),
     )
     assert expected == artifact.originalChecksums
-
-
-@pytest.mark.parametrize(
-    "file_info",
-    [
-        pytest.param(
-            {
-                **FILE_INFO_RESPONSE.copy(),
-                "originalChecksums": {"sha224": "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f"},
-            },
-            id="sha224",
-        ),
-    ],
-)
-@responses.activate
-def test_deploy_artifact_with_checksum_algorithms_error(file_info: dict):
-    responses.add(responses.PUT, f"{URL}/{ARTIFACT_PATH}", status=409)
-
-    responses.add(
-        responses.GET,
-        f"{URL}/api/storage/{ARTIFACT_PATH}",
-        json=file_info,
-        status=200,
-    )
-    with pytest.raises(Exception):
-        artifactory = ArtifactoryArtifact(AuthModel(url=URL, auth=AUTH))
-        artifactory.deploy(
-            Path(LOCAL_FILE_LOCATION),
-            Path(ARTIFACT_PATH),
-            checksum_algorithms=file_info["originalChecksums"].keys(),
-        )
 
 
 @responses.activate


### PR DESCRIPTION
## Description

Artifactory UI shows a warning message in the uploaded artifacts when artifact checksums aren't provided, therefore we would like to push a checksum of binaries being deployed.

Pushing checksums doesn't seem to be a well documented feature in the JFrog documentation, however here is brief reference to it https://jfrog.com/help/r/why-am-i-getting-client-did-not-publish-a-checksum-value-for-npm-packages/why-am-i-getting-client-did-not-publish-a-checksum-value...-for-npm-packages

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [x] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [x] All commits have a correct title
- [x] Readme has been updated
- [x] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
