### PR TITLE
Fix validation error when trying to access build info

### DIFF
--- a/pyartifactory/models/build.py
+++ b/pyartifactory/models/build.py
@@ -63,8 +63,8 @@ class BuildArtifact(BaseModel):
 class BuildModules(BaseModel):
     """Models artifactory's build modules."""
 
-    properties: Dict[str, str]
-    type: str
+    properties: Optional[Dict[str, str]] = None
+    type: Optional[str] = None
     id: str
     artifacts: List[BuildArtifact]
 


### PR DESCRIPTION
## Description & how has it been tested

Before these changes, calling `art.builds.get_build_info(NAME, BUILD_NO)` would result in a validation error and exception
```
ValidationError: 2 validation errors for BuildInfo
buildInfo.modules.0.properties
  Field required [type=missing, input_value={'id': 'PATH/TO/FILE}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
buildInfo.modules.0.type
  Field required [type=missing, input_value={'id': 'PATH/TO/FILE}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

After these changes `art.builds.get_build_info(NAME, BUILD_NO)` returns a `BuildInfo` object that can be interacted with.

### Commit

* Make properties and type optional for BuildModules

Neither field is listed as `required` in the buildinfo schema at https://github.com/jfrog/build-info-go/blob/main/buildinfo-schema.json

These were also not present in a live instance of Artifactory, causing validation errors for a BuildInfo

## Type of change

- [A] Bug fix (non-breaking change which fixes an issue)
- [B] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Either A or B, depends how deep users expectations go regarding the fields.

## Checklist:

- [X] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [X] All commits have a correct title
- My PR does not affect what is covered in the README.md
- My PR does not change the number of passing and failing tests.
