### PR TITLE
Add support for deleting all build numbers of a given build name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This library enables you to manage Artifactory resources such as users, groups, 
     + [Create build](#create-build)
     + [Promote a build](#promote-a-build)
     + [Delete one or more builds](#delete-one-or-more-builds)
+    + [Delete all build numbers of a build](#delete-all-build-numbers-of-a-build)
     + [Rename a build](#rename-a-build)
     + [Get differences between two builds](#get-differences-between-two-builds)
   * [Contributing](#contributing)
@@ -550,6 +551,12 @@ promote_build: BuildPromotionResult = art.builds.promote_build("<build_name>", "
 #### Delete one or more builds
 ```python
 build_delete_request = BuildDeleteRequest(buildName="<build_name>", buildNumbers=["<build_number>", "<another_build_number>", ...])
+art.builds.delete(build_delete_request)
+```
+
+#### Delete all build numbers of a build
+```python
+build_delete_request = BuildDeleteRequest(buildName="<build_name>", deleteAll=True)
 art.builds.delete(build_delete_request)
 ```
 

--- a/pyartifactory/models/build.py
+++ b/pyartifactory/models/build.py
@@ -63,8 +63,8 @@ class BuildArtifact(BaseModel):
 class BuildModules(BaseModel):
     """Models artifactory's build modules."""
 
-    properties: Dict[str, str]
-    type: str
+    properties: Optional[Dict[str, str]] = None
+    type: Optional[str] = None
     id: str
     artifacts: List[BuildArtifact]
 

--- a/pyartifactory/objects/build.py
+++ b/pyartifactory/objects/build.py
@@ -120,13 +120,19 @@ class ArtifactoryBuild(ArtifactoryObject):
         :return: None
         """
         try:
-            for _build_number in delete_build.buildNumbers:
-                self._get(
-                    f"api/{self._uri}/{delete_build.buildName}/{_build_number}",
-                )
-            # all build numbers exist
+            if delete_build.buildNumbers:
+                for _build_number in delete_build.buildNumbers:
+                    self._get(
+                        f"api/{self._uri}/{delete_build.buildName}/{_build_number}",
+                    )
+                # all build numbers exist
+
             self._post(f"api/{self._uri}/delete", json=delete_build.model_dump())
-            logger.debug("Builds %s deleted from %s", ",".join(delete_build.buildNumbers), delete_build.buildName)
+
+            if delete_build.buildNumbers:
+                logger.debug("Builds %s deleted from %s", ",".join(delete_build.buildNumbers), delete_build.buildName)
+            else:
+                logger.debug("Deleted all builds of %s", delete_build.buildName)
         except requests.exceptions.HTTPError as error:
             self._raise_exception(error)
 


### PR DESCRIPTION
## Description

Adds option to delete all build numbers of a given **build name**.

Using _Bitbucket Branch Source Plugin_ in Jenkins will with it's default behaviour create a larger number of named builds with slightly different build names. This option makes it easier to cleanup a large number of non relevant build info from Artifactory.

After https://github.com/anancarv/python-artifactory/pull/214

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Deleted build info and artifacts with `BuildDeleteRequest(buildName="THE_BUILD", deleteArtifacts=True, buildNumbers=["1", "2"])`
- [X] Deleted build info and artifacts with `BuildDeleteRequest(buildName="THE_BUILD", deleteArtifacts=True, deleteAll=True)`

## Checklist:

- [ ] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [X] All commits have a correct title
- [X] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [X] Automated tests are green (see pipeline)
